### PR TITLE
Fix panic for salutation-only names

### DIFF
--- a/name-parser/name_parser.go
+++ b/name-parser/name_parser.go
@@ -121,7 +121,7 @@ func Parse(input string) *Name {
 		for j := i; j < end; j++ {
 			lastName = lastName + " " + fixCase(nameParts[j])
 		}
-	} else {
+	} else if i < len(nameParts) {
 		firstName = fixCase(nameParts[i])
 	}
 

--- a/name-parser/name_paser_test.go
+++ b/name-parser/name_paser_test.go
@@ -22,6 +22,8 @@ func TestNames(t *testing.T) {
 	names["Mark P Williams"] = &Name{"", "Mark", "P", "Williams", ""}
 	names["Aaron bin Omar"] = &Name{"", "Aaron", "", "bin Omar", ""}
 	names["Aaron ibn Omar"] = &Name{"", "Aaron", "", "ibn Omar", ""}
+	names[""] = &Name{"", "", "", "", ""}
+	names["Dr"] = &Name{"Dr.", "", "", "", ""}
 
 	for rawName, expectedResult := range names {
 		result := Parse(rawName)


### PR DESCRIPTION
In cases where only a salutation was provided, the code would get to this point with i = 1 and len(nameParts) = 0, causing a slice index out of range panic. Added a unit test for this case and also the empty string case.