### PR TITLE
Include caller of exception constructor in stack trace

### DIFF
--- a/exception/exception_test.go
+++ b/exception/exception_test.go
@@ -105,7 +105,7 @@ func TestCallers(t *testing.T) {
 
 	a.NotNil(callStack)
 	callstackStr := fmt.Sprintf("%+v", callStack)
-	a.True(strings.Contains(callstackStr, "testing.tRunner"), callstackStr)
+	a.True(strings.Contains(callstackStr, "TestCallers"), callstackStr)
 }
 
 func TestExceptionFormatters(t *testing.T) {

--- a/exception/stack_trace.go
+++ b/exception/stack_trace.go
@@ -12,7 +12,7 @@ import (
 func callers() *StackPointers {
 	const depth = 32
 	var pcs [depth]uintptr
-	n := runtime.Callers(4, pcs[:])
+	n := runtime.Callers(3, pcs[:])
 	var st StackPointers = pcs[0:n]
 	return &st
 }

--- a/exception/stack_trace_test.go
+++ b/exception/stack_trace_test.go
@@ -2,7 +2,6 @@ package exception
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
@@ -46,9 +45,4 @@ func TestExceptionWithStackStrings(t *testing.T) {
 	assert.NotEmpty(values["Stack"])
 
 	assert.NotNil(ex.Stack())
-}
-
-func TestExceptionStackTraceCallersOffset(t *testing.T) {
-	assert := assert.New(t)
-	assert.True(strings.Contains(fmt.Sprintf("%v", New("foo").Stack()), "stack_trace_test.go"))
 }

--- a/exception/stack_trace_test.go
+++ b/exception/stack_trace_test.go
@@ -2,6 +2,7 @@ package exception
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
@@ -45,4 +46,9 @@ func TestExceptionWithStackStrings(t *testing.T) {
 	assert.NotEmpty(values["Stack"])
 
 	assert.NotNil(ex.Stack())
+}
+
+func TestExceptionStackTraceCallersOffset(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(strings.Contains(fmt.Sprintf("%v", New("foo").Stack()), "stack_trace_test.go"))
 }


### PR DESCRIPTION
Changes the stack offset used in callers() from 4 to 3 so the caller of exception.New, Newf, etc. is included in the stack trace.