### PR TITLE
Return the error as a string in JSONResultProvider.BadRequest()

### DIFF
--- a/web/json_result_provider.go
+++ b/web/json_result_provider.go
@@ -49,7 +49,7 @@ func (jrp *JSONResultProvider) BadRequest(err error) Result {
 	if err != nil {
 		return &JSONResult{
 			StatusCode: http.StatusBadRequest,
-			Response:   err,
+			Response:   err.Error(),
 		}
 	}
 	return &JSONResult{


### PR DESCRIPTION
The current behavior returns the error directly, which is serialized to an empty JSON object `{}`.  I'm not sure if you're relying on this behavior anywhere to send detailed error objects, but this will make the behavior consistent with JSONResultProvider.InternalError()