### PR TITLE
Add Intellij project files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 profile.cov
 coverage.cov
 coverage.html
+
+# IntelliJ-isms
+.idea
+*.ipr
+*.iml


### PR DESCRIPTION
I use intellij for golang development and would like to permanently exclude the IDE's project files from git commits.