### PR TITLE
Fix exception marshaling

### DIFF
--- a/exception/exception.go
+++ b/exception/exception.go
@@ -160,7 +160,7 @@ func (e *Ex) Error() string {
 // Decompose breaks the exception down to be marshalled into an intermediate format.
 func (e *Ex) Decompose() map[string]interface{} {
 	values := map[string]interface{}{}
-	values["Class"] = e.class
+	values["Class"] = e.class.Error()
 	values["Message"] = e.message
 	if e.stack != nil {
 		values["Stack"] = e.Stack().Strings()

--- a/exception/exception_test.go
+++ b/exception/exception_test.go
@@ -117,7 +117,8 @@ func TestMarshalJSON(t *testing.T) {
 	}
 
 	a := assert.New(t)
-	ex := New("new test error")
+	message := "new test error"
+	ex := New(message)
 	a.NotNil(ex)
 	stackTrace := ex.Stack()
 	typed, isTyped := stackTrace.(StackPointers)
@@ -133,6 +134,25 @@ func TestMarshalJSON(t *testing.T) {
 	err = json.Unmarshal(jsonErr, ex2)
 	a.Nil(err)
 	a.Len(ex2.Stack, stackDepth)
+	a.Equal(message, ex2.Class)
+
+	ex = New(fmt.Errorf(message))
+	a.NotNil(ex)
+	stackTrace = ex.Stack()
+	typed, isTyped = stackTrace.(StackPointers)
+	a.True(isTyped)
+	a.NotNil(typed)
+	stackDepth = len(typed)
+
+	jsonErr, err = json.Marshal(ex)
+	a.Nil(err)
+	a.NotNil(jsonErr)
+
+	ex2 = &ReadableStackTrace{}
+	err = json.Unmarshal(jsonErr, ex2)
+	a.Nil(err)
+	a.Len(ex2.Stack, stackDepth)
+	a.Equal(message, ex2.Class)
 }
 
 func TestNest(t *testing.T) {


### PR DESCRIPTION
Currently, if an Exception is created from an error object (e.g. `exception.New(fmt.Errorf("..."))`), the original error message is lost because `Ex.Class` isn't marshaled as string. In that case, the marshaled string will look like this: 
```
{"Class":{},"Message":"","Stack":["..."]}
```