### PR TITLE
Fix and new method on Request

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -394,6 +394,13 @@ func (r *Request) WithPostData(field string, value string) *Request {
 	return r
 }
 
+// LookupPostData gets the first value set on the request via the WithPostData func associated with the given key.
+// If there are no values associated with the key, LookupPostData returns the empty string. This is a useful retrieval
+// mechanism for mocks
+func (r *Request) LookupPostData(field string) string {
+	return r.postData.Get(field)
+}
+
 // WithPostedFile adds a posted file to the multipart form elements of the request.
 func (r *Request) WithPostedFile(key, fileName string, fileContents io.Reader) *Request {
 	r.postedFiles = append(r.postedFiles, PostedFile{Key: key, FileName: fileName, FileContents: fileContents})
@@ -900,9 +907,13 @@ func (r *Request) deserialize(handler Deserializer) (*ResponseMeta, error) {
 func (r *Request) deserializeWithError(okHandler Deserializer, errorHandler Deserializer) (*ResponseMeta, error) {
 	res, err := r.Response()
 	if err != nil {
+		if res != nil {
+			// If there is both an error and a response, we make an attempt to build a ResponseMeta
+			return safeNewResponseMeta(res), err
+		}
 		return nil, exception.New(err)
 	}
-	// do not move this above the error or else risk a nil ref from the response
+
 	meta := NewResponseMeta(res)
 
 	defer res.Body.Close()
@@ -924,6 +935,16 @@ func (r *Request) deserializeWithError(okHandler Deserializer, errorHandler Dese
 		}
 	}
 	return meta, exception.New(err)
+}
+
+func safeNewResponseMeta(res *http.Response) (meta *ResponseMeta) {
+	defer func() {
+		if r := recover(); r != nil {
+			meta = nil
+		}
+	}()
+	meta = NewResponseMeta(res)
+	return
 }
 
 func (r *Request) logRequest() {

--- a/request/request.go
+++ b/request/request.go
@@ -394,10 +394,10 @@ func (r *Request) WithPostData(field string, value string) *Request {
 	return r
 }
 
-// LookupPostData gets the first value set on the request via the WithPostData func associated with the given key.
-// If there are no values associated with the key, LookupPostData returns the empty string. This is a useful retrieval
+// GetPostData gets the first value set on the request via the WithPostData func associated with the given key.
+// If there are no values associated with the key, GetPostData returns the empty string. This is a useful retrieval
 // mechanism for mocks
-func (r *Request) LookupPostData(field string) string {
+func (r *Request) GetPostData(field string) string {
 	return r.postData.Get(field)
 }
 

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -186,6 +187,24 @@ func TestHttpGetWithErrorHandler(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(http.StatusInternalServerError, meta.StatusCode)
 	assert.Equal(returnedObject, errorObject)
+}
+
+func TestHttpGetWithFullMockedError(t *testing.T) {
+	assert := assert.New(t)
+	url := "http://localhost:5001/api/v2/err"
+	req := New().WithMethod("GET").MustWithRawURL(url).WithMockProvider(
+		func(_ *Request) *MockedResponse {
+			return &MockedResponse{
+				Meta: ResponseMeta{StatusCode: http.StatusInternalServerError},
+				Err:  errors.New("this is a test error"),
+			}
+		})
+	testObject := testObject{}
+	errorObject := errorObject{}
+	meta, err := req.JSONWithErrorHandler(&testObject, &errorObject)
+	assert.NotNil(err)
+	assert.Equal("this is a test error", err.Error())
+	assert.Equal(http.StatusInternalServerError, meta.StatusCode)
 }
 
 func TestHttpGetWithExpiringTimeout(t *testing.T) {


### PR DESCRIPTION
- Fixes an issue where the status code and other metadata are not returned from the request in the case of a 500.
- Adds a retrieval method for post data