### PR TITLE
Allow a handle to the LocalSessionCache underlying LocalAuthManager

### DIFF
--- a/web/auth_manager.go
+++ b/web/auth_manager.go
@@ -39,6 +39,17 @@ func NewAuthManagerFromConfig(cfg *Config) (manager *AuthManager) {
 		WithSessionTimeoutProvider(SessionTimeoutProvider(cfg.GetSessionTimeoutIsAbsolute(), cfg.GetSessionTimeout()))
 }
 
+// NewLocalAuthManager returns a new locally cached session manager that saves sessions to the cache provided
+func NewLocalAuthManagerFromCache(cache *LocalSessionCache) *AuthManager {
+	return &AuthManager{
+		persistHandler: cache.PersistHandler,
+		fetchHandler:   cache.FetchHandler,
+		removeHandler:  cache.RemoveHandler,
+		cookieName:     DefaultCookieName,
+		cookiePath:     DefaultCookiePath,
+	}
+}
+
 // NewLocalAuthManager returns a new locally cached session manager.
 // It saves sessions to a local store.
 func NewLocalAuthManager() *AuthManager {


### PR DESCRIPTION
For the Local Session Cache, create it in such a way that the application can maintain a handle to the cache object. Useful for testing.