### PR TITLE
Separate default tags into Taggable interface

### DIFF
--- a/stats/collector.go
+++ b/stats/collector.go
@@ -4,7 +4,7 @@ import "time"
 
 // Collector is a stats collector.
 type Collector interface {
-	Tagger
+	Taggable
 	Count(name string, value int64, tags ...string) error
 	Increment(name string, tags ...string) error
 	Gauge(name string, value float64, tags ...string) error

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -4,8 +4,7 @@ import "time"
 
 // Collector is a stats collector.
 type Collector interface {
-	AddDefaultTag(string, string)
-	DefaultTags() []string
+	Tagger
 	Count(name string, value int64, tags ...string) error
 	Increment(name string, tags ...string) error
 	Gauge(name string, value float64, tags ...string) error

--- a/stats/event_collector.go
+++ b/stats/event_collector.go
@@ -8,8 +8,7 @@ import (
 
 // EventCollector is a collector for events.
 type EventCollector interface {
-	AddDefaultTag(key, value string)
-	DefaultTags() []string
+	Tagger
 	SendEvent(Event) error
 	CreateEvent(title, text string, tags ...string) Event
 }

--- a/stats/event_collector.go
+++ b/stats/event_collector.go
@@ -8,7 +8,7 @@ import (
 
 // EventCollector is a collector for events.
 type EventCollector interface {
-	Tagger
+	Taggable
 	SendEvent(Event) error
 	CreateEvent(title, text string, tags ...string) Event
 }

--- a/stats/tagger.go
+++ b/stats/tagger.go
@@ -1,7 +1,7 @@
 package stats
 
-// Tagger is an interface for specifying and retrieving default stats tags
-type Tagger interface {
+// Taggable is an interface for specifying and retrieving default stats tags
+type Taggable interface {
 	AddDefaultTag(string, string)
 	DefaultTags() []string
 }

--- a/stats/tagger.go
+++ b/stats/tagger.go
@@ -1,0 +1,7 @@
+package stats
+
+// Tagger is an interface for specifying and retrieving default stats tags
+type Tagger interface {
+	AddDefaultTag(string, string)
+	DefaultTags() []string
+}


### PR DESCRIPTION
We have a use case for combining these interfaces into a single interface that handles both, but right now we cannot because the functions related to default tags step on each other. This allows us to do something like

```go
type StatsThing interface {
	stats.Collector
	stats.EventCollector
}
```
which previously wouldn't compile.