### PR TITLE
Fix Nil Check in requesttrace Finish()

### DIFF
--- a/stats/tracing/requesttrace/tracer.go
+++ b/stats/tracing/requesttrace/tracer.go
@@ -34,7 +34,7 @@ type requestTraceFinisher struct {
 }
 
 func (rtf requestTraceFinisher) Finish(req *http.Request, meta *request.ResponseMeta, err error) {
-	if rtf.span != nil {
+	if rtf.span == nil {
 		return
 	}
 	tracing.SpanError(rtf.span, err)


### PR DESCRIPTION
Expected behavior should be the finish the span if it exists