### PR TITLE
Use db.Config.Schema to build the psql search_path

### DIFF
--- a/db/config_test.go
+++ b/db/config_test.go
@@ -31,7 +31,7 @@ func TestConfigCreateDSN(t *testing.T) {
 		SSLMode:  SSLModeVerifyCA,
 	}
 
-	assert.Equal("postgres://bailey:dog@bar:1234/blend?sslmode=verify-ca&search_path=mortgages", cfg.CreateDSN())
+	assert.Equal("postgres://bailey:dog@bar:1234/blend?search_path=mortgages&sslmode=verify-ca", cfg.CreateDSN())
 
 	cfg = &Config{
 		Host:     "bar",

--- a/db/config_test.go
+++ b/db/config_test.go
@@ -31,7 +31,7 @@ func TestConfigCreateDSN(t *testing.T) {
 		SSLMode:  SSLModeVerifyCA,
 	}
 
-	assert.Equal("postgres://bailey:dog@bar:1234/blend?sslmode=verify-ca", cfg.CreateDSN())
+	assert.Equal("postgres://bailey:dog@bar:1234/blend?sslmode=verify-ca&search_path=mortgages", cfg.CreateDSN())
 
 	cfg = &Config{
 		Host:     "bar",
@@ -42,7 +42,7 @@ func TestConfigCreateDSN(t *testing.T) {
 		Schema:   "mortgages",
 	}
 
-	assert.Equal("postgres://bailey:dog@bar:1234/blend", cfg.CreateDSN())
+	assert.Equal("postgres://bailey:dog@bar:1234/blend?search_path=mortgages", cfg.CreateDSN())
 
 	cfg = &Config{
 		Host:     "bar",


### PR DESCRIPTION
Concerns with this: Its technically a breaking change if people are expecting Schema to not impact the search_path and don't have their DB User to have the specified schema front their search path.