### PR TITLE
Adds a way to shortcut db invocations with an error.

### DIFF
--- a/db/invocation.go
+++ b/db/invocation.go
@@ -23,6 +23,7 @@ type Invocation struct {
 	TraceFinisher        TraceFinisher
 	StartTime            time.Time
 	Tx                   *sql.Tx
+	Err                  error
 }
 
 // Prepare returns a cached or newly prepared statment plan for a given sql statement.
@@ -852,6 +853,9 @@ func (i *Invocation) CloseStatement(stmt *sql.Stmt, err error) error {
 
 // Start runs on start steps.
 func (i *Invocation) Start(statement string) (string, error) {
+	if i.Err != nil {
+		return "", i.Err
+	}
 	if i.StatementInterceptor != nil {
 		var err error
 		statement, err = i.StatementInterceptor(i.CachedPlanKey, statement)

--- a/db/invocation_test.go
+++ b/db/invocation_test.go
@@ -653,3 +653,16 @@ func TestConnectionCreateIfNotExists(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(oldCategory, verify.Category)
 }
+
+func TestInvocationEarlyExitOnError(t *testing.T) {
+	assert := assert.New(t)
+	tx, err := defaultDB().Begin()
+	assert.Nil(err)
+	defer tx.Rollback()
+
+	i := defaultDB().Invoke(OptTx(tx))
+	assert.Nil(i.Exec("select 1"))
+
+	i.Err = fmt.Errorf("this is a test")
+	assert.Equal("this is a test", i.Exec("select 1").Error())
+}


### PR DESCRIPTION
## PR Summary

Allows db invocations to be pre-empted by an error on construction. Not useful in the sdk now, but useful in libraries that wrap it.

 - **Type:** Improvements
 - **Issue Link:** N/A
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.