### PR TITLE
DB Invocation method return refactor

### DIFF
--- a/db/column.go
+++ b/db/column.go
@@ -72,11 +72,7 @@ func (c Column) SetValue(object interface{}, value interface{}) error {
 
 	valueReflected := ReflectValue(value)
 	if !valueReflected.IsValid() {
-		if field.Kind() == reflect.Ptr {
-			field.Set(reflect.Zero(field.Type()))
-		} else {
-			field.Set(reflect.Zero(ReflectType(value)))
-		}
+		field.Set(reflect.Zero(field.Type()))
 		return nil
 	}
 

--- a/db/column.go
+++ b/db/column.go
@@ -72,7 +72,11 @@ func (c Column) SetValue(object interface{}, value interface{}) error {
 
 	valueReflected := ReflectValue(value)
 	if !valueReflected.IsValid() {
-		field.Set(reflect.Zero(ReflectType(value)))
+		if field.Kind() == reflect.Ptr {
+			field.Set(reflect.Zero(field.Type()))
+		} else {
+			field.Set(reflect.Zero(ReflectType(value)))
+		}
 		return nil
 	}
 

--- a/db/column.go
+++ b/db/column.go
@@ -61,6 +61,14 @@ type Column struct {
 	Inline       bool
 }
 
+// EmptyValue sets the empty value on a field on a database mapped object
+func (c Column) EmptyValue(object interface{}) error {
+	objValue := ReflectValue(object)
+	field := objValue.FieldByName(c.FieldName)
+	field.Set(reflect.Zero(field.Type()))
+	return nil
+}
+
 // SetValue sets the field on a database mapped object to the instance of `value`.
 func (c Column) SetValue(object interface{}, value interface{}) error {
 	objValue := ReflectValue(object)

--- a/db/column.go
+++ b/db/column.go
@@ -61,8 +61,8 @@ type Column struct {
 	Inline       bool
 }
 
-// EmptyValue sets the empty value on a field on a database mapped object
-func (c Column) EmptyValue(object interface{}) {
+// SetZero sets the empty value on a field on a database mapped object
+func (c Column) SetZero(object interface{}) {
 	objValue := ReflectValue(object)
 	field := objValue.FieldByName(c.FieldName)
 	field.Set(reflect.Zero(field.Type()))

--- a/db/column.go
+++ b/db/column.go
@@ -72,6 +72,7 @@ func (c Column) SetValue(object interface{}, value interface{}) error {
 
 	valueReflected := ReflectValue(value)
 	if !valueReflected.IsValid() {
+		field.Set(reflect.Zero(ReflectType(value)))
 		return nil
 	}
 

--- a/db/column.go
+++ b/db/column.go
@@ -62,15 +62,14 @@ type Column struct {
 }
 
 // EmptyValue sets the empty value on a field on a database mapped object
-func (c Column) EmptyValue(object interface{}) error {
+func (c Column) EmptyValue(object interface{}) {
 	objValue := ReflectValue(object)
 	field := objValue.FieldByName(c.FieldName)
 	field.Set(reflect.Zero(field.Type()))
-	return nil
 }
 
 // SetValue sets the field on a database mapped object to the instance of `value`.
-func (c Column) SetValue(object interface{}, value interface{}) error {
+func (c Column) SetValue(object interface{}, value interface{}, clearEmpty bool) error {
 	objValue := ReflectValue(object)
 	field := objValue.FieldByName(c.FieldName)
 	fieldType := field.Type()
@@ -80,7 +79,9 @@ func (c Column) SetValue(object interface{}, value interface{}) error {
 
 	valueReflected := ReflectValue(value)
 	if !valueReflected.IsValid() {
-		field.Set(reflect.Zero(field.Type()))
+		if clearEmpty {
+			field.Set(reflect.Zero(field.Type()))
+		}
 		return nil
 	}
 

--- a/db/column_test.go
+++ b/db/column_test.go
@@ -15,7 +15,7 @@ func TestSetValue(t *testing.T) {
 	value = 10
 	meta := CachedColumnCollectionFromInstance(obj)
 	pk := meta.Columns()[0]
-	a.Nil(pk.SetValue(&obj, value))
+	a.Nil(pk.SetValue(&obj, value, true))
 	a.Equal(10, obj.PrimaryKeyCol)
 }
 
@@ -26,7 +26,7 @@ func TestSetValueConverted(t *testing.T) {
 	meta := CachedColumnCollectionFromInstance(obj)
 	col := meta.Lookup()["big_int"]
 	a.NotNil(col)
-	err := col.SetValue(&obj, int(21))
+	err := col.SetValue(&obj, int(21), true)
 	a.Nil(err)
 	a.Equal(21, obj.BigIntColumn)
 }
@@ -38,7 +38,7 @@ func TestSetValueJSON(t *testing.T) {
 
 	col := meta.Lookup()["json_col"]
 	a.NotNil(col)
-	err := col.SetValue(&obj, sql.NullString{String: `{"foo":"bar"}`, Valid: true})
+	err := col.SetValue(&obj, sql.NullString{String: `{"foo":"bar"}`, Valid: true}, true)
 	a.Nil(err)
 	a.Equal("bar", obj.JSONColumn.Foo)
 }
@@ -51,7 +51,7 @@ func TestSetValuePtr(t *testing.T) {
 	col := meta.Lookup()["pointer_col"]
 	a.NotNil(col)
 	myValue := 21
-	err := col.SetValue(&obj, &myValue)
+	err := col.SetValue(&obj, &myValue, true)
 	a.Nil(err)
 	a.NotNil(obj.PointerColumn)
 	a.Equal(21, *obj.PointerColumn)

--- a/db/connection.go
+++ b/db/connection.go
@@ -210,12 +210,12 @@ func (dbc *Connection) DefaultSchema() string {
 }
 
 // Exec is a helper stub for .Invoke(...).Exec(...).
-func (dbc *Connection) Exec(statement string, args ...interface{}) error {
+func (dbc *Connection) Exec(statement string, args ...interface{}) (int, error) {
 	return dbc.Invoke().Exec(statement, args...)
 }
 
 // ExecContext is a helper stub for .Invoke(OptContext(ctx)).Exec(...).
-func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) error {
+func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) (int, error) {
 	return dbc.Invoke(OptContext(ctx)).Exec(statement, args...)
 }
 

--- a/db/connection.go
+++ b/db/connection.go
@@ -210,12 +210,12 @@ func (dbc *Connection) DefaultSchema() string {
 }
 
 // Exec is a helper stub for .Invoke(...).Exec(...).
-func (dbc *Connection) Exec(statement string, args ...interface{}) (int, error) {
+func (dbc *Connection) Exec(statement string, args ...interface{}) (int64, error) {
 	return dbc.Invoke().Exec(statement, args...)
 }
 
 // ExecContext is a helper stub for .Invoke(OptContext(ctx)).Exec(...).
-func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) (int, error) {
+func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) (int64, error) {
 	return dbc.Invoke(OptContext(ctx)).Exec(statement, args...)
 }
 

--- a/db/connection_test.go
+++ b/db/connection_test.go
@@ -66,13 +66,16 @@ func TestConnectionStatementCacheExecute(t *testing.T) {
 	a.Nil(conn.Open())
 	defer conn.Close()
 	conn.PlanCache.WithEnabled(true)
-
-	a.Nil(conn.Exec("select 'ok!'"))
-	a.Nil(conn.Exec("select 'ok!'"))
+	_, err = conn.Exec("select 'ok!'")
+	a.Nil(err)
+	_, err = conn.Exec("select 'ok!'")
+	a.Nil(err)
 	a.False(conn.PlanCache.HasStatement("select 'ok!'"))
 
-	a.Nil(conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'"))
-	a.Nil(conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'"))
+	_, err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
+	a.Nil(err)
+	_, err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
+	a.Nil(err)
 	a.True(conn.PlanCache.HasStatement("ping"))
 }
 
@@ -115,7 +118,7 @@ func TestExec(t *testing.T) {
 	a.Nil(err)
 	defer tx.Rollback()
 
-	err = defaultDB().Invoke(OptTx(tx)).Exec("select 'ok!'")
+	_, err = defaultDB().Invoke(OptTx(tx)).Exec("select 'ok!'")
 	a.Nil(err)
 }
 
@@ -136,23 +139,23 @@ func TestConnectionInvalidatesBadCachedStatements(t *testing.T) {
 	queryStatement := `SELECT * from state_invalidation`
 
 	defer func() {
-		err = conn.Exec(dropTableStatement)
+		_, err = conn.Exec(dropTableStatement)
 		assert.Nil(err)
 	}()
 
-	err = conn.Exec(createTableStatement)
+	_, err = conn.Exec(createTableStatement)
 	assert.Nil(err)
 
-	err = conn.Exec(insertStatement, 1, "Foo")
+	_, err = conn.Exec(insertStatement, 1, "Foo")
 	assert.Nil(err)
 
-	err = conn.Exec(insertStatement, 2, "Bar")
+	_, err = conn.Exec(insertStatement, 2, "Bar")
 	assert.Nil(err)
 
 	_, err = conn.Query(queryStatement).Any()
 	assert.Nil(err)
 
-	err = conn.Exec(alterTableStatement)
+	_, err = conn.Exec(alterTableStatement)
 	assert.Nil(err)
 
 	// normally this would result in a busted cached query plan.

--- a/db/constants.go
+++ b/db/constants.go
@@ -1,6 +1,8 @@
 package db
 
-import "time"
+import (
+	"time"
+)
 
 const (
 	// DefaultEngine is the default database engine.

--- a/db/errors.go
+++ b/db/errors.go
@@ -31,6 +31,8 @@ const (
 	ErrNoPrimaryKey ex.Class = "db: no primary key on object"
 	// ErrRowsNotColumnsProvider is returned by `PopulateByName` if you do not pass in `sql.Rows` as the scanner.
 	ErrRowsNotColumnsProvider ex.Class = "db: rows is not a columns provider"
+	// ErrTooManyRows is returned by Out if there is more than one row returned by the query
+	ErrTooManyRows ex.Class = "db: too many rows returned to map to single object"
 )
 
 // IsConfigUnset returns if the error is an `ErrConfigUnset`.

--- a/db/invocation.go
+++ b/db/invocation.go
@@ -39,7 +39,7 @@ func (i *Invocation) Prepare(statement string) (stmt *sql.Stmt, err error) {
 }
 
 // Exec executes a sql statement with a given set of arguments.
-func (i *Invocation) Exec(statement string, args ...interface{}) (rowsAffected int, err error) {
+func (i *Invocation) Exec(statement string, args ...interface{}) (rowsAffected int64, err error) {
 	var stmt *sql.Stmt
 	statement, err = i.Start(statement)
 	defer func() { err = i.Finish(statement, recover(), err) }()
@@ -61,8 +61,7 @@ func (i *Invocation) Exec(statement string, args ...interface{}) (rowsAffected i
 	}
 	// The error here is intentionally ignored. Postgres supports this. We'd need to revisit swallowing this error
 	// for other drivers
-	ra64, _ := res.RowsAffected()
-	rowsAffected = int(ra64)
+	rowsAffected, _ = res.RowsAffected()
 	return
 }
 
@@ -252,11 +251,11 @@ func (i *Invocation) Update(object DatabaseMapped) (updated bool, err error) {
 	}
 	// The error here is intentionally ignored. Postgres supports this. We'd need to revisit swallowing this error
 	// for other drivers
-	ra64, _ := res.RowsAffected()
-	if ra64 > 0 {
+	rowCount, _ := res.RowsAffected()
+	if rowCount > 0 {
 		updated = true
 	}
-	if ra64 > 1 {
+	if rowCount > 1 {
 		err = Error(ErrTooManyRows)
 	}
 	return

--- a/db/invocation.go
+++ b/db/invocation.go
@@ -39,7 +39,7 @@ func (i *Invocation) Prepare(statement string) (stmt *sql.Stmt, err error) {
 }
 
 // Exec executes a sql statement with a given set of arguments.
-func (i *Invocation) Exec(statement string, args ...interface{}) (err error) {
+func (i *Invocation) Exec(statement string, args ...interface{}) (rowsAffected int, err error) {
 	var stmt *sql.Stmt
 	statement, err = i.Start(statement)
 	defer func() { err = i.Finish(statement, recover(), err) }()
@@ -54,10 +54,15 @@ func (i *Invocation) Exec(statement string, args ...interface{}) (err error) {
 	}
 	defer func() { err = i.CloseStatement(stmt, err) }()
 
-	if _, err = stmt.ExecContext(i.Context, args...); err != nil {
+	res, err := stmt.ExecContext(i.Context, args...)
+	if err != nil {
 		err = Error(err)
 		return
 	}
+	// The error here is intentionally ignored. Postgres supports this. We'd need to revisit swallowing this error
+	// for other drivers
+	ra64, _ := res.RowsAffected()
+	rowsAffected = int(ra64)
 	return
 }
 
@@ -78,96 +83,29 @@ func (i *Invocation) Query(statement string, args ...interface{}) *Query {
 }
 
 // Get returns a given object based on a group of primary key ids within a transaction.
-func (i *Invocation) Get(object DatabaseMapped, ids ...interface{}) (err error) {
+func (i *Invocation) Get(object DatabaseMapped, ids ...interface{}) (found bool, err error) {
 	if len(ids) == 0 {
 		err = Error(ErrInvalidIDs)
 		return
 	}
 
 	var queryBody string
-	var stmt *sql.Stmt
-	var cols *ColumnCollection
-	defer func() { err = i.Finish(queryBody, recover(), err) }()
-
-	if i.CachedPlanKey, queryBody, cols, err = i.generateGet(object); err != nil {
+	if i.CachedPlanKey, queryBody, err = i.generateGet(object); err != nil {
 		err = Error(err)
 		return
 	}
 
-	queryBody, err = i.Start(queryBody)
-	if err != nil {
-		return
-	}
-	if stmt, err = i.Prepare(queryBody); err != nil {
-		err = ex.New(err)
-		return
-	}
-	defer func() { err = i.CloseStatement(stmt, err) }()
-
-	row := stmt.QueryRowContext(i.Context, ids...)
-	var populateErr error
-	if typed, ok := object.(Populatable); ok {
-		populateErr = typed.Populate(row)
-	} else {
-		populateErr = PopulateInOrder(object, row, cols)
-	}
-	if populateErr != nil && !ex.Is(populateErr, sql.ErrNoRows) {
-		err = Error(populateErr)
-		return
-	}
-
-	return
+	return i.Query(queryBody, ids...).Out(object)
 }
 
 // All returns all rows of an object mapped table wrapped in a transaction.
 func (i *Invocation) All(collection interface{}) (err error) {
 	var queryBody string
-	var stmt *sql.Stmt
-	var rows *sql.Rows
-	var cols *ColumnCollection
-	var collectionType reflect.Type
 	defer func() { err = i.Finish(queryBody, recover(), err) }()
 
-	i.CachedPlanKey, queryBody, cols, collectionType = i.generateGetAll(collection)
+	i.CachedPlanKey, queryBody = i.generateGetAll(collection)
 
-	queryBody, err = i.Start(queryBody)
-	if err != nil {
-		return
-	}
-	if stmt, err = i.Prepare(queryBody); err != nil {
-		err = Error(err)
-		return
-	}
-	defer func() { err = i.CloseStatement(stmt, err) }()
-
-	if rows, err = stmt.QueryContext(i.Context); err != nil {
-		err = Error(err)
-		return
-	}
-	defer func() { err = ex.Nest(err, rows.Close()) }()
-
-	collectionValue := ReflectValue(collection)
-	for rows.Next() {
-		var obj interface{}
-		if obj, err = MakeNewDatabaseMapped(collectionType); err != nil {
-			err = ex.New(err)
-			return
-		}
-
-		if typed, ok := obj.(Populatable); ok {
-			err = typed.Populate(rows)
-		} else {
-			err = PopulateInOrder(obj, rows, cols)
-		}
-		if err != nil {
-			err = Error(err)
-			return
-		}
-
-		objValue := ReflectValue(obj)
-		collectionValue.Set(reflect.Append(collectionValue, objValue))
-	}
-	return
+	return i.Query(queryBody).OutMany(collection)
 }
 
 // Create writes an object to the database within a transaction.
@@ -286,8 +224,11 @@ func (i *Invocation) CreateMany(objects interface{}) (err error) {
 	return
 }
 
-// Update updates an object wrapped in a transaction.
-func (i *Invocation) Update(object DatabaseMapped) (err error) {
+// Update updates an object wrapped in a transaction. Returns whether or not any rows have been updated and potentially
+// an error. If ErrTooManyRows is returned, it's important to note that due to https://github.com/golang/go/issues/7898,
+// the Update HAS BEEN APPLIED. Its on the developer using UPDATE to ensure his tags are correct and/or execute it in a
+// transaction and roll back on this error
+func (i *Invocation) Update(object DatabaseMapped) (updated bool, err error) {
 	var queryBody string
 	var stmt *sql.Stmt
 	var pks, writeCols *ColumnCollection
@@ -304,10 +245,19 @@ func (i *Invocation) Update(object DatabaseMapped) (err error) {
 		return
 	}
 	defer func() { err = i.CloseStatement(stmt, err) }()
-
-	if _, err = stmt.ExecContext(i.Context, append(writeCols.ColumnValues(object), pks.ColumnValues(object)...)...); err != nil {
+	res, err := stmt.ExecContext(i.Context, append(writeCols.ColumnValues(object), pks.ColumnValues(object)...)...)
+	if err != nil {
 		err = Error(err)
 		return
+	}
+	// The error here is intentionally ignored. Postgres supports this. We'd need to revisit swallowing this error
+	// for other drivers
+	ra64, _ := res.RowsAffected()
+	if ra64 > 0 {
+		updated = true
+	}
+	if ra64 > 1 {
+		err = Error(ErrTooManyRows)
 	}
 	return
 }
@@ -383,8 +333,11 @@ func (i *Invocation) Exists(object DatabaseMapped) (exists bool, err error) {
 	return
 }
 
-// Delete deletes an object from the database wrapped in a transaction.
-func (i *Invocation) Delete(object DatabaseMapped) (err error) {
+// Delete deletes an object from the database wrapped in a transaction. Returns whether or not any rows have been deleted
+// and potentially an error. If ErrTooManyRows is returned, it's important to note that due to
+// https://github.com/golang/go/issues/7898, the Delete HAS BEEN APPLIED on the current transaction. Its on the
+// developer using Delete to ensure their tags are correct and/or ensure theit Tx rolls back on this error.
+func (i *Invocation) Delete(object DatabaseMapped) (deleted bool, err error) {
 	var queryBody string
 	var stmt *sql.Stmt
 	var pks *ColumnCollection
@@ -403,35 +356,19 @@ func (i *Invocation) Delete(object DatabaseMapped) (err error) {
 		return
 	}
 	defer func() { err = i.CloseStatement(stmt, err) }()
-
-	if _, err = stmt.ExecContext(i.Context, pks.ColumnValues(object)...); err != nil {
-		err = Error(err)
-		return
-	}
-	return
-}
-
-// Truncate completely empties a table in a single command.
-func (i *Invocation) Truncate(object DatabaseMapped) (err error) {
-	var queryBody string
-	var stmt *sql.Stmt
-	defer func() { err = i.Finish(queryBody, recover(), err) }()
-
-	i.CachedPlanKey, queryBody = i.generateTruncate(object)
-
-	queryBody, err = i.Start(queryBody)
+	res, err := stmt.ExecContext(i.Context, pks.ColumnValues(object)...);
 	if err != nil {
-		return
-	}
-	if stmt, err = i.Prepare(queryBody); err != nil {
 		err = Error(err)
 		return
 	}
-	defer func() { err = i.CloseStatement(stmt, err) }()
-
-	if _, err = stmt.ExecContext(i.Context); err != nil {
-		err = Error(err)
-		return
+	// The error here is intentionally ignored. Postgres supports this. We'd need to revisit swallowing this error
+	// for other drivers
+	ra64, _ := res.RowsAffected()
+	if ra64 > 0 {
+		deleted = true
+	}
+	if ra64 > 1 {
+		err = Error(ErrTooManyRows)
 	}
 	return
 }
@@ -440,10 +377,10 @@ func (i *Invocation) Truncate(object DatabaseMapped) (err error) {
 // query body generators
 // --------------------------------------------------------------------------------
 
-func (i *Invocation) generateGet(object DatabaseMapped) (statementLabel, queryBody string, cols *ColumnCollection, err error) {
+func (i *Invocation) generateGet(object DatabaseMapped) (cachePlan, queryBody string, err error) {
 	tableName := TableName(object)
 
-	cols = CachedColumnCollectionFromInstance(object).NotReadOnly()
+	cols := CachedColumnCollectionFromInstance(object).NotReadOnly()
 	pks := cols.PrimaryKeys()
 	if pks.Len() == 0 {
 		err = Error(ErrNoPrimaryKey)
@@ -474,17 +411,17 @@ func (i *Invocation) generateGet(object DatabaseMapped) (statementLabel, queryBo
 		}
 	}
 
-	statementLabel = tableName + "_get"
+	cachePlan = fmt.Sprintf("%s_get", tableName)
 	queryBody = queryBodyBuffer.String()
 	i.Conn.BufferPool.Put(queryBodyBuffer)
 	return
 }
 
-func (i *Invocation) generateGetAll(collection interface{}) (statementLabel, queryBody string, cols *ColumnCollection, collectionType reflect.Type) {
-	collectionType = ReflectSliceType(collection)
+func (i *Invocation) generateGetAll(collection interface{}) (statementLabel, queryBody string) {
+	collectionType := ReflectSliceType(collection)
 	tableName := TableNameByType(collectionType)
 
-	cols = CachedColumnCollectionFromType(tableName, ReflectSliceType(collection)).NotReadOnly()
+	cols := CachedColumnCollectionFromType(tableName, ReflectSliceType(collection)).NotReadOnly()
 
 	queryBodyBuffer := i.Conn.BufferPool.Get()
 	queryBodyBuffer.WriteString("SELECT ")
@@ -799,19 +736,6 @@ func (i *Invocation) generateDelete(object DatabaseMapped) (statementLabel, quer
 	return
 }
 
-func (i *Invocation) generateTruncate(object DatabaseMapped) (statmentLabel, queryBody string) {
-	tableName := TableName(object)
-
-	queryBodyBuffer := i.Conn.BufferPool.Get()
-	queryBodyBuffer.WriteString("TRUNCATE ")
-	queryBodyBuffer.WriteString(tableName)
-
-	queryBody = queryBodyBuffer.String()
-	statmentLabel = tableName + "_truncate"
-	i.Conn.BufferPool.Put(queryBodyBuffer)
-	return
-}
-
 // --------------------------------------------------------------------------------
 // helpers
 // --------------------------------------------------------------------------------
@@ -828,7 +752,7 @@ func (i *Invocation) AutoValues(autos *ColumnCollection) []interface{} {
 // SetAutos sets the automatic values for a given object.
 func (i *Invocation) SetAutos(object DatabaseMapped, autos *ColumnCollection, autoValues []interface{}) (err error) {
 	for index := 0; index < len(autoValues); index++ {
-		err = autos.Columns()[index].SetValue(object, autoValues[index])
+		err = autos.Columns()[index].SetValue(object, autoValues[index], false)
 		if err != nil {
 			err = Error(err)
 			return

--- a/db/invocation_test.go
+++ b/db/invocation_test.go
@@ -666,3 +666,49 @@ func TestInvocationEarlyExitOnError(t *testing.T) {
 	i.Err = fmt.Errorf("this is a test")
 	assert.Equal("this is a test", i.Exec("select 1").Error())
 }
+
+type benchWithPointer struct {
+	ID        int       `db:"id,pk,auto"`
+	UUID      string    `db:"uuid,nullable,uk"`
+	Name      string    `db:"name"`
+	Timestamp *time.Time `db:"timestamp_utc"`
+	Amount    float32   `db:"amount"`
+	Pending   bool      `db:"pending"`
+	Category  string    `db:"category"`
+}
+
+func (t benchWithPointer) TableName() string {
+	return "bench_object"
+}
+
+func TestOutWithDirtyStructs(t *testing.T) {
+	assert := assert.New(t)
+	tx, err := defaultDB().Begin()
+	assert.Nil(err)
+	defer tx.Rollback()
+
+	err = createTable(tx)
+	assert.Nil(err)
+
+	uniq := uuid.V4().ToFullString()
+
+	err = defaultDB().Invoke(OptTx(tx)).Exec("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
+		uniq, "Foo", "Bar")
+	assert.Nil(err)
+
+	timeObj := time.Now()
+
+	dirty := benchWithPointer{
+		ID: 192,
+		UUID: uuid.V4().ToFullString(),
+		Name: "Widget",
+		Timestamp: &timeObj,
+		Amount: 4.99,
+		Category: "Baz",
+	}
+
+	err = defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).Out(&dirty)
+	assert.Nil(err)
+	assert.Nil(dirty.Timestamp)
+	assert.True(dirty.Amount == 0)
+}

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -113,7 +113,8 @@ func (uo upsertObj) TableName() string {
 
 func createUpserObjectTable(tx *sql.Tx) error {
 	createSQL := `CREATE TABLE IF NOT EXISTS upsert_object (uuid varchar(255) primary key, timestamp_utc timestamp, category varchar(255));`
-	return defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
+	_, err := defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
+	return err
 }
 
 //------------------------------------------------------------------------------------------------
@@ -148,17 +149,21 @@ func createTable(tx *sql.Tx) error {
 		, pending boolean
 		, category varchar(255)
 	);`
-	return defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
+	i, err := defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
+	fmt.Printf("Count: %d", i)
+	return err
 }
 
 func dropTableIfExists(tx *sql.Tx) error {
 	dropSQL := `DROP TABLE IF EXISTS bench_object;`
-	return defaultDB().Invoke(OptTx(tx)).Exec(dropSQL)
+	_, err := defaultDB().Invoke(OptTx(tx)).Exec(dropSQL)
+	return err
 }
 
 func ensureUUIDExtension() error {
 	uuidCreate := `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
-	return defaultDB().Exec(uuidCreate)
+	_, err := defaultDB().Exec(uuidCreate)
+	return err
 }
 
 func createObject(index int, tx *sql.Tx) error {

--- a/db/migration/action.go
+++ b/db/migration/action.go
@@ -22,7 +22,7 @@ func NoOp(_ context.Context, _ *db.Connection, _ *sql.Tx) error { return nil }
 func Statements(statements ...string) Action {
 	return func(ctx context.Context, c *db.Connection, tx *sql.Tx) (err error) {
 		for _, statement := range statements {
-			err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement)
+			_, err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement)
 			if err != nil {
 				return
 			}
@@ -35,7 +35,7 @@ func Statements(statements ...string) Action {
 // It can be used in lieu of Statements, when parameterization is needed
 func Exec(statement string, args ...interface{}) Action {
 	return func(ctx context.Context, c *db.Connection, tx *sql.Tx) (err error) {
-		err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement, args...)
+		_, err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement, args...)
 		return
 	}
 }

--- a/db/migration/data_file_reader.go
+++ b/db/migration/data_file_reader.go
@@ -94,7 +94,7 @@ func (dfr *DataFileReader) Action(ctx context.Context, c *db.Connection, tx *sql
 				continue
 			}
 
-			err = c.Invoke(db.OptTx(tx)).Exec(line)
+			_, err = c.Invoke(db.OptTx(tx)).Exec(line)
 			if err != nil {
 				return
 			}

--- a/db/migration/data_file_reader_test.go
+++ b/db/migration/data_file_reader_test.go
@@ -146,7 +146,7 @@ func TestDataFileReaderAction(t *testing.T) {
 	a := assert.New(t)
 	conn := getSchemaConnection(db.DefaultSchema, a)
 	testSchemaName := buildTestSchemaName()
-	err := conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	_, err := conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 	a.Nil(err)
 	dfr := ReadDataFile("./testdata/data_file_reader_test.sql")
 	s := New(OptLog(logger.None()), OptGroups(createDataFileMigrations(testSchemaName)...))
@@ -156,7 +156,7 @@ func TestDataFileReaderAction(t *testing.T) {
 			c = defaultDB()
 		}
 		// pq can't parameterize Drop
-		err := c.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		_, err := c.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), conn)
@@ -193,7 +193,7 @@ func createDataFileMigrations(testSchemaName string) []*Group {
 				Actions(
 					// pq can't parameterize Create
 					func(i context.Context, connection *db.Connection, tx *sql.Tx) error {
-						err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
+						_, err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
 						if err != nil {
 							return err
 						}

--- a/db/migration/guard_predicates_test.go
+++ b/db/migration/guard_predicates_test.go
@@ -42,7 +42,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE table_test_foo (id serial not null primary key, something varchar(32) not null)")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE table_test_foo (id serial not null primary key, something varchar(32) not null)")
 	assert.Nil(err)
 
 	didRun = false
@@ -59,7 +59,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD CONSTRAINT constraint_foo UNIQUE (something)")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD CONSTRAINT constraint_foo UNIQUE (something)")
 	assert.Nil(err)
 
 	didRun = false
@@ -76,7 +76,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD COLUMN created_foo timestamp not null")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD COLUMN created_foo timestamp not null")
 	assert.Nil(err)
 
 	didRun = false
@@ -93,7 +93,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_foo ON table_test_foo(created_foo DESC)")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_foo ON table_test_foo(created_foo DESC)")
 	assert.Nil(err)
 
 	didRun = false
@@ -114,7 +114,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	iName := "index_bar"
 	tName := "table_test_bar"
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE SCHEMA schema_test_bar")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE SCHEMA schema_test_bar")
 	assert.Nil(err)
 
 	var didRun bool
@@ -131,7 +131,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE schema_test_bar.table_test_bar (id serial not null primary key, something varchar(32) not null, created timestamp not null)")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE schema_test_bar.table_test_bar (id serial not null primary key, something varchar(32) not null, created timestamp not null)")
 	assert.Nil(err)
 
 	didRun = false
@@ -148,7 +148,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD CONSTRAINT constraint_bar UNIQUE (something)")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD CONSTRAINT constraint_bar UNIQUE (something)")
 	assert.Nil(err)
 
 	didRun = false
@@ -165,7 +165,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD COLUMN created_bar timestamp not null")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD COLUMN created_bar timestamp not null")
 	assert.Nil(err)
 
 	didRun = false
@@ -182,7 +182,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_bar ON schema_test_bar.table_test_bar(created_bar DESC)")
+	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_bar ON schema_test_bar.table_test_bar(created_bar DESC)")
 	assert.Nil(err)
 
 	didRun = false

--- a/db/migration/predicates_test.go
+++ b/db/migration/predicates_test.go
@@ -33,7 +33,8 @@ func createTestTable(tableName string, tx *sql.Tx) error {
 
 func insertTestValue(tableName string, id int, name string, tx *sql.Tx) error {
 	body := fmt.Sprintf("INSERT INTO %s (id, name) VALUES ($1, $2);", tableName)
-	return defaultDB().Invoke(db.OptTx(tx)).Exec(body, id, name)
+	_, err := defaultDB().Invoke(db.OptTx(tx)).Exec(body, id, name)
+	return err
 }
 
 func createTestColumn(tableName, columnName string, tx *sql.Tx) error {

--- a/db/migration/suite_test.go
+++ b/db/migration/suite_test.go
@@ -13,12 +13,12 @@ import (
 func TestSuite_Apply(t *testing.T) {
 	a := assert.New(t)
 	testSchemaName := buildTestSchemaName()
-	err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 	a.Nil(err)
 	s := New(OptLog(logger.None()), OptGroups(createTestMigrations(testSchemaName)...))
 	defer func() {
 		// pq can't parameterize Drop
-		err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), defaultDB())
@@ -38,13 +38,13 @@ func TestSuite_Apply(t *testing.T) {
 func TestSuite_ApplyFails(t *testing.T) {
 	a := assert.New(t)
 	testSchemaName := buildTestSchemaName()
-	err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 	a.Nil(err)
 	s := New(OptLog(logger.None()), OptGroups(createTestMigrations(testSchemaName)...))
 	s.Groups = append(s.Groups, NewGroupWithActions(NewStep(Always(), Actions(Statements(`INSERT INTO tab_not_exists VALUES (1, 'blah', CURRENT_TIMESTAMP');`)))))
 	defer func() {
 		// pq can't parameterize Drop
-		err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), defaultDB())
@@ -69,7 +69,7 @@ func createTestMigrations(testSchemaName string) []*Group {
 				Actions(
 					// pq can't parameterize Create
 					func(i context.Context, connection *db.Connection, tx *sql.Tx) error {
-						err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
+						_, err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
 						if err != nil {
 							return err
 						}

--- a/db/populate.go
+++ b/db/populate.go
@@ -27,6 +27,11 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection) error 
 
 	err = row.Scan(values...)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			for _, v := range columnLookup {
+				v.EmptyValue(object)
+			}
+		}
 		return Error(err)
 	}
 
@@ -57,6 +62,11 @@ func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection)
 	}
 
 	if err = row.Scan(values...); err != nil {
+		if err == sql.ErrNoRows {
+			for _, v := range cols.Columns() {
+				v.EmptyValue(object)
+			}
+		}
 		err = ex.New(err)
 		return
 	}

--- a/db/populate.go
+++ b/db/populate.go
@@ -11,7 +11,7 @@ import (
 func PopulateEmpty(object interface{}, cols *ColumnCollection) {
 	var columnLookup = cols.Lookup()
 	for _, v := range columnLookup {
-		v.EmptyValue(object)
+		v.SetZero(object)
 	}
 }
 

--- a/db/populate.go
+++ b/db/populate.go
@@ -57,36 +57,6 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, clearE
 	return nil
 }
 
-// PopulateInOrder sets the values of an object in order from a sql.Rows object.
-// Only use this method if you're certain of the column order. It is faster than populateByName.
-// Optionally if your object implements Populatable this process will be skipped completely, which is even faster.
-func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection, clearEmpty bool) (err error) {
-	var values = make([]interface{}, cols.Len())
-
-	for i, col := range cols.Columns() {
-		initColumnValue(i, values, &col)
-	}
-
-	if clearEmpty {
-		PopulateEmpty(object, cols)
-	}
-	if err = row.Scan(values...); err != nil {
-		return Error(err)
-	}
-
-	columns := cols.Columns()
-	var field Column
-	for i, v := range values {
-		field = columns[i]
-		if err = field.SetValue(object, v, clearEmpty); err != nil {
-			err = ex.New(err)
-			return
-		}
-	}
-
-	return
-}
-
 // initColumnValue inserts the correct placeholder in the scan array of values.
 // it will use `sql.Null` forms where appropriate.
 // JSON fields are implicitly nullable.

--- a/db/populate.go
+++ b/db/populate.go
@@ -57,6 +57,36 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, clearE
 	return nil
 }
 
+// PopulateInOrder sets the values of an object in order from a sql.Rows object.
+// Only use this method if you're certain of the column order. It is faster than populateByName.
+// Optionally if your object implements Populatable this process will be skipped completely, which is even faster.
+func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection, clearEmpty bool) (err error) {
+	var values = make([]interface{}, cols.Len())
+
+	for i, col := range cols.Columns() {
+		initColumnValue(i, values, &col)
+	}
+
+	if clearEmpty {
+		PopulateEmpty(object, cols)
+	}
+	if err = row.Scan(values...); err != nil {
+		return Error(err)
+	}
+
+	columns := cols.Columns()
+	var field Column
+	for i, v := range values {
+		field = columns[i]
+		if err = field.SetValue(object, v, clearEmpty); err != nil {
+			err = ex.New(err)
+			return
+		}
+	}
+
+	return
+}
+
 // initColumnValue inserts the correct placeholder in the scan array of values.
 // it will use `sql.Null` forms where appropriate.
 // JSON fields are implicitly nullable.

--- a/db/populate.go
+++ b/db/populate.go
@@ -34,10 +34,10 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, clearE
 	}
 
 	err = row.Scan(values...)
+	if clearEmpty {
+		PopulateEmpty(object, cols)
+	}
 	if err != nil {
-		if err == sql.ErrNoRows && clearEmpty {
-			PopulateEmpty(object, cols)
-		}
 		return Error(err)
 	}
 
@@ -67,12 +67,11 @@ func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection,
 		initColumnValue(i, values, &col)
 	}
 
+	if clearEmpty {
+		PopulateEmpty(object, cols)
+	}
 	if err = row.Scan(values...); err != nil {
-		if err == sql.ErrNoRows && clearEmpty {
-			PopulateEmpty(object, cols)
-		}
-		err = ex.New(err)
-		return
+		return Error(err)
 	}
 
 	columns := cols.Columns()

--- a/db/util.go
+++ b/db/util.go
@@ -5,9 +5,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/blend/go-sdk/ex"
 )
 
 // --------------------------------------------------------------------------------
@@ -131,15 +128,6 @@ func ParamTokensCSV(num int) string {
 	return str
 }
 
-// MakeNewDatabaseMapped returns a new instance of a database mapped type.
-func MakeNewDatabaseMapped(t reflect.Type) (DatabaseMapped, error) {
-	newInterface := reflect.New(t).Interface()
-	if typed, isTyped := newInterface.(DatabaseMapped); isTyped {
-		return typed.(DatabaseMapped), nil
-	}
-	return nil, ex.New("type does not implement DatabaseMapped", ex.OptMessagef("type: %s", t.Name()))
-}
-
 // makeNew creates a new object.
 func makeNew(t reflect.Type) interface{} {
 	return reflect.New(t).Interface()
@@ -147,12 +135,4 @@ func makeNew(t reflect.Type) interface{} {
 
 func makeSliceOfType(t reflect.Type) interface{} {
 	return reflect.New(reflect.SliceOf(t)).Interface()
-}
-
-func now() time.Time {
-	return time.Now().UTC()
-}
-
-func since(ts time.Time) time.Duration {
-	return now().Sub(ts)
 }

--- a/examples/db/bench/main.go
+++ b/examples/db/bench/main.go
@@ -89,7 +89,8 @@ func main() {
 
 	for x := 0; x < 1<<12; x++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
-		maybeFatal(conn.Invoke(db.OptContext(ctx)).Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", tableName), strconv.Itoa(x)))
+		_, err := conn.Invoke(db.OptContext(ctx)).Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", tableName), strconv.Itoa(x))
+		maybeFatal(err)
 		cancel()
 	}
 

--- a/examples/db/migration/timeouts/main.go
+++ b/examples/db/migration/timeouts/main.go
@@ -16,7 +16,8 @@ func main() {
 			migration.NewStep(
 				migration.Always(),
 				func(ctx context.Context, connection *db.Connection, tx *sql.Tx) error {
-					return connection.Invoke(db.OptTimeout(500 * time.Millisecond)).Exec("select pg_sleep(10);")
+					_, err := connection.Invoke(db.OptTimeout(500 * time.Millisecond)).Exec("select pg_sleep(10);")
+					return err
 				},
 			),
 		),

--- a/stats/tracing/dbtrace/main_test.go
+++ b/stats/tracing/dbtrace/main_test.go
@@ -48,5 +48,6 @@ func createTable(tx *sql.Tx) error {
 	createSQL := `CREATE TABLE IF NOT EXISTS test_table (
 		id serial not null primary key
 	);`
-	return defaultDB().Invoke(db.OptTx(tx)).Exec(createSQL)
+	_, err := defaultDB().Invoke(db.OptTx(tx)).Exec(createSQL)
+	return err
 }


### PR DESCRIPTION
## PR Summary

This started out trying to solve for the fact that Query.Out() is leaving junk in structs it writes to, if the new values from the db are "zero values."

It turned into a refactor of a bunch of behaviors in the db package around what is returned from things. The highlights:

For method return signatures:
`Out()`, `Delete()`, `Update()`, and `Get()` are changing to (bool, err) where the bool indicates an object has been found/deleted/updated. They also error if more than one matching row is found. `ErrTooManyRows`
`Exec()` is changing to (int, err) where the int is the number of rows affected if applicable
`Create()`, `CreateMany()`,`Upsert()` and, `CreateIfNotExists()` remain the same
`Truncate()` helper has been removed

`Out()` and `Get()` now scrub the structs they populate when no rows are returned. They also scrub any db-tagged fields in the struct that are not in the result set, or are in the result set but have "empty" values.

`Into()` is a new method on Query that can be used to chain populate a struct. It does not clear any of the aforementioned data.  

 - **Type:** Bugfix and Refactor
 - **Issue Link:** 
 - **Intended Change Level:** major

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.