### PR TITLE
Adding `Forbidden()` and `Unauthorized()` result providers.

### DIFF
--- a/web/json_result_provider.go
+++ b/web/json_result_provider.go
@@ -30,6 +30,14 @@ func (jrp JSONResultProvider) NotAuthorized() Result {
 	}
 }
 
+// Forbidden returns a 403 Forbidden response.
+func (jrp JSONResultProvider) Forbidden() Result {
+	return &JSONResult{
+		StatusCode: http.StatusForbidden,
+		Response:   "Forbidden",
+	}
+}
+
 // InternalError returns a service response.
 func (jrp JSONResultProvider) InternalError(err error) Result {
 	if err != nil {

--- a/web/json_result_provider.go
+++ b/web/json_result_provider.go
@@ -25,7 +25,7 @@ func (jrp JSONResultProvider) NotFound() Result {
 // NotAuthorized returns a service response.
 func (jrp JSONResultProvider) NotAuthorized() Result {
 	return &JSONResult{
-		StatusCode: http.StatusForbidden,
+		StatusCode: http.StatusUnauthorized,
 		Response:   "Not Authorized",
 	}
 }

--- a/web/json_result_provider_test.go
+++ b/web/json_result_provider_test.go
@@ -21,6 +21,11 @@ func TestJSONResultProvider(t *testing.T) {
 	assert.Equal(http.StatusForbidden, notAuthorized.StatusCode)
 	assert.Equal("Not Authorized", notAuthorized.Response)
 
+	forbidden, ok := JSON.Forbidden().(*JSONResult)
+	assert.True(ok)
+	assert.Equal(http.StatusForbidden, forbidden.StatusCode)
+	assert.Equal("Forbidden", forbidden.Response)
+
 	badRequest, ok := JSON.BadRequest(nil).(*JSONResult)
 	assert.True(ok)
 	assert.Equal(http.StatusBadRequest, badRequest.StatusCode)

--- a/web/json_result_provider_test.go
+++ b/web/json_result_provider_test.go
@@ -18,7 +18,7 @@ func TestJSONResultProvider(t *testing.T) {
 
 	notAuthorized, ok := JSON.NotAuthorized().(*JSONResult)
 	assert.True(ok)
-	assert.Equal(http.StatusForbidden, notAuthorized.StatusCode)
+	assert.Equal(http.StatusUnauthorized, notAuthorized.StatusCode)
 	assert.Equal("Not Authorized", notAuthorized.Response)
 
 	forbidden, ok := JSON.Forbidden().(*JSONResult)


### PR DESCRIPTION
## PR Summary

*Replace this text with a description of what this PR is accomplishing*

 - **Type:** Features
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- I was surprised to find out that `web.JSONResultProvider.NotAuthorized()` actually returns a 403 Forbidden