### PR TITLE
DB Refactor of the Refactor

### DIFF
--- a/db/column.go
+++ b/db/column.go
@@ -131,8 +131,7 @@ func (c Column) SetValue(object interface{}, value interface{}) error {
 			// what should we do here?
 			return ex.New("cannot convert value to destination pointer type")
 		}
-
-		return ex.New("cannot take address of value")
+		return ex.New("cannot take address of value for assignment to object field (which is itself a pointer)")
 	}
 
 	// convert and assign

--- a/db/column.go
+++ b/db/column.go
@@ -69,7 +69,7 @@ func (c Column) SetZero(object interface{}) {
 }
 
 // SetValue sets the field on a database mapped object to the instance of `value`.
-func (c Column) SetValue(object interface{}, value interface{}, clearEmpty bool) error {
+func (c Column) SetValue(object interface{}, value interface{}, resetRowEmpty bool) error {
 	objValue := ReflectValue(object)
 	field := objValue.FieldByName(c.FieldName)
 	fieldType := field.Type()
@@ -79,7 +79,7 @@ func (c Column) SetValue(object interface{}, value interface{}, clearEmpty bool)
 
 	valueReflected := ReflectValue(value)
 	if !valueReflected.IsValid() {
-		if clearEmpty {
+		if resetRowEmpty {
 			field.Set(reflect.Zero(field.Type()))
 		}
 		return nil

--- a/db/column.go
+++ b/db/column.go
@@ -169,7 +169,8 @@ func (c Column) SetValueReflected(objectValue reflect.Value, value interface{}) 
 
 // haveSameUnderlyingTypes returns if T and V are such that V is *T or V is **T etc.
 // It handles the cases where we're assigning T = convert(**T) which can happen when we're setting up
-// scan output array.s
+// scan output array.
+// Convert can smush T and **T together somehow.
 func haveSameUnderlyingTypes(t, v reflect.Value) bool {
 	tt := t.Type()
 	tv := ReflectType(v)

--- a/db/column_test.go
+++ b/db/column_test.go
@@ -72,9 +72,48 @@ func TestSetValueNil(t *testing.T) {
 	a.NotNil(col)
 
 	var myValue *int
-	err := col.SetValue(&obj, &myValue)
+	err := col.SetValue(&obj, myValue)
 	a.Nil(err)
 	a.Nil(obj.PointerColumn)
+}
+
+func TestSetValueSQLNullable(t *testing.T) {
+	a := assert.New(t)
+
+	obj := myStruct{
+		Unique:        "foo",
+		PointerColumn: ref.Int(1234),
+	}
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["unique"]
+	a.NotNil(col)
+
+	myValue := sql.NullString{
+		String: "bar",
+		Valid:  true,
+	}
+	err := col.SetValue(&obj, myValue)
+	a.Nil(err)
+	a.Equal("bar", obj.Unique)
+}
+
+func TestSetValueSQLNullableInvalid(t *testing.T) {
+	a := assert.New(t)
+
+	obj := myStruct{
+		Unique:        "foo",
+		PointerColumn: ref.Int(1234),
+	}
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["unique"]
+	a.NotNil(col)
+
+	myValue := sql.NullString{}
+	err := col.SetValue(&obj, myValue)
+	a.Nil(err)
+	a.Equal("", obj.Unique)
 }
 
 func TestGetValue(t *testing.T) {

--- a/db/column_test.go
+++ b/db/column_test.go
@@ -8,73 +8,267 @@ import (
 	"github.com/blend/go-sdk/ref"
 )
 
+type jsonFieldValue struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+type setValueTest struct {
+	PrimaryKey   string `db:"primary_key,pk"`
+	UniqueKey    string `db:"unique_key,uk"`
+	InferredName string
+	NullFloat64  sql.NullFloat64        `db:"null_float64"`
+	NullInt64    sql.NullInt64          `db:"null_int64"`
+	NullString   sql.NullString         `db:"null_string"`
+	JSON         map[string]interface{} `db:"json_col,json"`
+	JSONPtr      *jsonFieldValue        `db:"json_ptr,json"`
+	Int64        int64                  `db:"int64"`
+	Int64Ptr     *int64                 `db:"int64_ptr"`
+	StringPtr    *string                `db:"string_ptr"`
+}
+
 func TestSetValue(t *testing.T) {
 	a := assert.New(t)
 
-	obj := myStruct{InferredName: "Hello."}
-
-	var value interface{}
-	value = 10
+	var obj setValueTest
 	meta := CachedColumnCollectionFromInstance(obj)
-	pk := meta.Columns()[0]
-	a.Nil(pk.SetValue(&obj, value))
-	a.Equal(10, obj.PrimaryKeyCol)
+	col := meta.Lookup()["int64"]
+	a.NotNil(col)
+
+	var value int64 = 10
+	a.Zero(obj.Int64)
+	a.Nil(col.SetValue(&obj, value))
+	a.Equal(10, obj.Int64)
 }
 
 func TestSetValueConverted(t *testing.T) {
 	a := assert.New(t)
 
-	obj := myStruct{InferredName: "Hello."}
-
+	obj := setValueTest{InferredName: "Hello."}
 	meta := CachedColumnCollectionFromInstance(obj)
-	col := meta.Lookup()["big_int"]
+	col := meta.Lookup()["int64"]
 	a.NotNil(col)
-	err := col.SetValue(&obj, int(21))
+
+	value := int(21)
+	err := col.SetValue(&obj, value)
 	a.Nil(err)
-	a.Equal(21, obj.BigIntColumn)
+	a.Equal(21, obj.Int64)
 }
 
-func TestSetValueJSON(t *testing.T) {
+func TestSetValuePtrAddr(t *testing.T) {
+	/*
+		Setting a value to an invalid value source shouldn't panic.
+	*/
+	t.Skip()
 	a := assert.New(t)
 
-	obj := myStruct{InferredName: "Hello."}
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+	col := meta.Lookup()["string_ptr"]
+	a.NotNil(col)
+
+	value := "foobar"
+	err := col.SetValue(&obj, value)
+	a.NotNil(err)
+	a.Nil(obj.StringPtr)
+}
+
+func TestSetValueStringPtr(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+	col := meta.Lookup()["string_ptr"]
+	a.NotNil(col)
+
+	value := "foobar"
+	err := col.SetValue(&obj, &value)
+	a.Nil(err)
+	a.NotNil(obj.StringPtr)
+	a.Equal("foobar", *obj.StringPtr)
+}
+
+func TestSetValueInt64Ptr(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["int64_ptr"]
+	a.NotNil(col)
+	myValue := int64(21)
+	err := col.SetValue(&obj, &myValue)
+	a.Nil(err)
+
+	a.NotNil(obj.Int64Ptr)
+	a.Equal(21, *obj.Int64Ptr)
+}
+
+func TestSetValueJSONNullString(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
 	meta := CachedColumnCollectionFromInstance(obj)
 
 	col := meta.Lookup()["json_col"]
 	a.NotNil(col)
-	err := col.SetValue(&obj, sql.NullString{String: `{"foo":"bar"}`, Valid: true})
+	err := col.SetValue(&obj,
+		sql.NullString{String: `{"foo":"bar"}`, Valid: true},
+	)
 	a.Nil(err)
-	a.Equal("bar", obj.JSONColumn.Foo)
+	a.Equal("bar", obj.JSON["foo"])
 }
 
-func TestSetValuePtr(t *testing.T) {
+func TestSetValueJSONNullStringUnset(t *testing.T) {
 	a := assert.New(t)
 
-	obj := myStruct{InferredName: "Hello."}
+	var obj setValueTest
 	meta := CachedColumnCollectionFromInstance(obj)
 
-	col := meta.Lookup()["pointer_col"]
+	col := meta.Lookup()["json_col"]
 	a.NotNil(col)
-	myValue := 21
-	err := col.SetValue(&obj, &myValue)
+	err := col.SetValue(&obj,
+		sql.NullString{},
+	)
 	a.Nil(err)
-	a.NotNil(obj.PointerColumn)
-	a.Equal(21, *obj.PointerColumn)
+	a.Nil(obj.JSON)
 }
 
-func TestSetValueNil(t *testing.T) {
+func TestSetValueJSONNullStringPtr(t *testing.T) {
 	a := assert.New(t)
 
-	obj := myStruct{PointerColumn: ref.Int(1234)}
+	var obj setValueTest
 	meta := CachedColumnCollectionFromInstance(obj)
 
-	col := meta.Lookup()["pointer_col"]
+	col := meta.Lookup()["json_col"]
+	a.NotNil(col)
+	err := col.SetValue(&obj,
+		&sql.NullString{String: `{"foo":"bar"}`, Valid: true},
+	)
+	a.Nil(err)
+	a.Equal("bar", obj.JSON["foo"])
+}
+
+func TestSetValueJSONNullStringPtrObjectPtr(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["json_ptr"]
+	a.NotNil(col)
+	err := col.SetValue(&obj,
+		&sql.NullString{String: `{"label":"foo", "value":"bar"}`, Valid: true},
+	)
+	a.Nil(err)
+	a.Equal("foo", obj.JSONPtr.Label)
+	a.Equal("bar", obj.JSONPtr.Value)
+}
+
+func TestSetValueJSONNullStringPtrUnset(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["json_col"]
+	a.NotNil(col)
+	err := col.SetValue(&obj,
+		&sql.NullString{},
+	)
+	a.Nil(err)
+	a.Nil(obj.JSON)
+}
+
+func TestSetValueJSONString(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["json_col"]
+	a.NotNil(col)
+	err := col.SetValue(&obj,
+		`{"foo":"bar"}`,
+	)
+	a.Nil(err)
+	a.Equal("bar", obj.JSON["foo"])
+}
+
+func TestSetValueJSONStringPtr(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["json_col"]
+	a.NotNil(col)
+	value := `{"foo":"bar"}`
+	err := col.SetValue(&obj,
+		&value,
+	)
+	a.Nil(err)
+	a.Equal("bar", obj.JSON["foo"])
+}
+
+func TestSetValueJSONBytes(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["json_col"]
+	a.NotNil(col)
+	value := []byte(`{"foo":"bar"}`)
+	err := col.SetValue(&obj,
+		value,
+	)
+	a.Nil(err)
+	a.Equal("bar", obj.JSON["foo"])
+}
+
+func TestSetValueJSONBytesPtr(t *testing.T) {
+	a := assert.New(t)
+
+	var obj setValueTest
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["json_col"]
+	a.NotNil(col)
+	value := []byte(`{"foo":"bar"}`)
+	err := col.SetValue(&obj,
+		&value,
+	)
+	a.Nil(err)
+	a.Equal("bar", obj.JSON["foo"])
+}
+
+func TestSetValueResetsNil(t *testing.T) {
+	a := assert.New(t)
+
+	obj := setValueTest{Int64Ptr: ref.Int64(1234)}
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["int64_ptr"]
+	a.NotNil(col)
+	err := col.SetValue(&obj, nil)
+	a.Nil(err)
+	a.Nil(obj.Int64Ptr)
+}
+
+func TestSetValueResetsNilUnset(t *testing.T) {
+	a := assert.New(t)
+
+	obj := setValueTest{Int64Ptr: ref.Int64(1234)}
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["int64_ptr"]
 	a.NotNil(col)
 
 	var myValue *int
 	err := col.SetValue(&obj, myValue)
 	a.Nil(err)
-	a.Nil(obj.PointerColumn)
+	a.Nil(obj.Int64Ptr)
 }
 
 func TestGetValue(t *testing.T) {

--- a/db/column_test.go
+++ b/db/column_test.go
@@ -77,45 +77,6 @@ func TestSetValueNil(t *testing.T) {
 	a.Nil(obj.PointerColumn)
 }
 
-func TestSetValueSQLNullable(t *testing.T) {
-	a := assert.New(t)
-
-	obj := myStruct{
-		Unique:        "foo",
-		PointerColumn: ref.Int(1234),
-	}
-	meta := CachedColumnCollectionFromInstance(obj)
-
-	col := meta.Lookup()["unique"]
-	a.NotNil(col)
-
-	myValue := sql.NullString{
-		String: "bar",
-		Valid:  true,
-	}
-	err := col.SetValue(&obj, myValue)
-	a.Nil(err)
-	a.Equal("bar", obj.Unique)
-}
-
-func TestSetValueSQLNullableInvalid(t *testing.T) {
-	a := assert.New(t)
-
-	obj := myStruct{
-		Unique:        "foo",
-		PointerColumn: ref.Int(1234),
-	}
-	meta := CachedColumnCollectionFromInstance(obj)
-
-	col := meta.Lookup()["unique"]
-	a.NotNil(col)
-
-	myValue := sql.NullString{}
-	err := col.SetValue(&obj, myValue)
-	a.Nil(err)
-	a.Equal("", obj.Unique)
-}
-
 func TestGetValue(t *testing.T) {
 	a := assert.New(t)
 	obj := myStruct{EmbeddedMeta: EmbeddedMeta{PrimaryKeyCol: 5}, InferredName: "Hello."}

--- a/db/column_test.go
+++ b/db/column_test.go
@@ -5,56 +5,76 @@ import (
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
+	"github.com/blend/go-sdk/ref"
 )
 
 func TestSetValue(t *testing.T) {
 	a := assert.New(t)
+
 	obj := myStruct{InferredName: "Hello."}
 
 	var value interface{}
 	value = 10
 	meta := CachedColumnCollectionFromInstance(obj)
 	pk := meta.Columns()[0]
-	a.Nil(pk.SetValue(&obj, value, true))
+	a.Nil(pk.SetValue(&obj, value))
 	a.Equal(10, obj.PrimaryKeyCol)
 }
 
 func TestSetValueConverted(t *testing.T) {
 	a := assert.New(t)
+
 	obj := myStruct{InferredName: "Hello."}
 
 	meta := CachedColumnCollectionFromInstance(obj)
 	col := meta.Lookup()["big_int"]
 	a.NotNil(col)
-	err := col.SetValue(&obj, int(21), true)
+	err := col.SetValue(&obj, int(21))
 	a.Nil(err)
 	a.Equal(21, obj.BigIntColumn)
 }
 
 func TestSetValueJSON(t *testing.T) {
 	a := assert.New(t)
+
 	obj := myStruct{InferredName: "Hello."}
 	meta := CachedColumnCollectionFromInstance(obj)
 
 	col := meta.Lookup()["json_col"]
 	a.NotNil(col)
-	err := col.SetValue(&obj, sql.NullString{String: `{"foo":"bar"}`, Valid: true}, true)
+	err := col.SetValue(&obj, sql.NullString{String: `{"foo":"bar"}`, Valid: true})
 	a.Nil(err)
 	a.Equal("bar", obj.JSONColumn.Foo)
 }
 
 func TestSetValuePtr(t *testing.T) {
 	a := assert.New(t)
+
 	obj := myStruct{InferredName: "Hello."}
 	meta := CachedColumnCollectionFromInstance(obj)
 
 	col := meta.Lookup()["pointer_col"]
 	a.NotNil(col)
 	myValue := 21
-	err := col.SetValue(&obj, &myValue, true)
+	err := col.SetValue(&obj, &myValue)
 	a.Nil(err)
 	a.NotNil(obj.PointerColumn)
 	a.Equal(21, *obj.PointerColumn)
+}
+
+func TestSetValueNil(t *testing.T) {
+	a := assert.New(t)
+
+	obj := myStruct{PointerColumn: ref.Int(1234)}
+	meta := CachedColumnCollectionFromInstance(obj)
+
+	col := meta.Lookup()["pointer_col"]
+	a.NotNil(col)
+
+	var myValue *int
+	err := col.SetValue(&obj, &myValue)
+	a.Nil(err)
+	a.Nil(obj.PointerColumn)
 }
 
 func TestGetValue(t *testing.T) {

--- a/db/connection.go
+++ b/db/connection.go
@@ -210,13 +210,23 @@ func (dbc *Connection) DefaultSchema() string {
 }
 
 // Exec is a helper stub for .Invoke(...).Exec(...).
-func (dbc *Connection) Exec(statement string, args ...interface{}) (int64, error) {
+func (dbc *Connection) Exec(statement string, args ...interface{}) error {
 	return dbc.Invoke().Exec(statement, args...)
 }
 
+// ExecStats is a helper stub for .Invoke(...).ExecStats(...).
+func (dbc *Connection) ExecStats(statement string, args ...interface{}) (int64, error) {
+	return dbc.Invoke().ExecStats(statement, args...)
+}
+
 // ExecContext is a helper stub for .Invoke(OptContext(ctx)).Exec(...).
-func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) (int64, error) {
+func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) error {
 	return dbc.Invoke(OptContext(ctx)).Exec(statement, args...)
+}
+
+// ExecStatsContext is a helper stub for .Invoke(OptContext(ctx)).Exec(...).
+func (dbc *Connection) ExecStatsContext(ctx context.Context, statement string, args ...interface{}) (int64, error) {
+	return dbc.Invoke(OptContext(ctx)).ExecStats(statement, args...)
 }
 
 // Query is a helper stub for .Invoke(...).Query(...).

--- a/db/connection.go
+++ b/db/connection.go
@@ -210,23 +210,13 @@ func (dbc *Connection) DefaultSchema() string {
 }
 
 // Exec is a helper stub for .Invoke(...).Exec(...).
-func (dbc *Connection) Exec(statement string, args ...interface{}) error {
+func (dbc *Connection) Exec(statement string, args ...interface{}) (sql.Result, error) {
 	return dbc.Invoke().Exec(statement, args...)
 }
 
-// ExecStats is a helper stub for .Invoke(...).ExecStats(...).
-func (dbc *Connection) ExecStats(statement string, args ...interface{}) (int64, error) {
-	return dbc.Invoke().ExecStats(statement, args...)
-}
-
 // ExecContext is a helper stub for .Invoke(OptContext(ctx)).Exec(...).
-func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) error {
+func (dbc *Connection) ExecContext(ctx context.Context, statement string, args ...interface{}) (sql.Result, error) {
 	return dbc.Invoke(OptContext(ctx)).Exec(statement, args...)
-}
-
-// ExecStatsContext is a helper stub for .Invoke(OptContext(ctx)).ExecStats(...).
-func (dbc *Connection) ExecStatsContext(ctx context.Context, statement string, args ...interface{}) (int64, error) {
-	return dbc.Invoke(OptContext(ctx)).ExecStats(statement, args...)
 }
 
 // Query is a helper stub for .Invoke(...).Query(...).

--- a/db/connection.go
+++ b/db/connection.go
@@ -224,7 +224,7 @@ func (dbc *Connection) ExecContext(ctx context.Context, statement string, args .
 	return dbc.Invoke(OptContext(ctx)).Exec(statement, args...)
 }
 
-// ExecStatsContext is a helper stub for .Invoke(OptContext(ctx)).Exec(...).
+// ExecStatsContext is a helper stub for .Invoke(OptContext(ctx)).ExecStats(...).
 func (dbc *Connection) ExecStatsContext(ctx context.Context, statement string, args ...interface{}) (int64, error) {
 	return dbc.Invoke(OptContext(ctx)).ExecStats(statement, args...)
 }

--- a/db/connection_test.go
+++ b/db/connection_test.go
@@ -66,15 +66,15 @@ func TestConnectionStatementCacheExecute(t *testing.T) {
 	a.Nil(conn.Open())
 	defer conn.Close()
 	conn.PlanCache.WithEnabled(true)
-	_, err = conn.Exec("select 'ok!'")
+	err = conn.Exec("select 'ok!'")
 	a.Nil(err)
-	_, err = conn.Exec("select 'ok!'")
+	err = conn.Exec("select 'ok!'")
 	a.Nil(err)
 	a.False(conn.PlanCache.HasStatement("select 'ok!'"))
 
-	_, err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
+	err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
 	a.Nil(err)
-	_, err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
+	err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
 	a.Nil(err)
 	a.True(conn.PlanCache.HasStatement("ping"))
 }
@@ -90,10 +90,12 @@ func TestConnectionStatementCacheQuery(t *testing.T) {
 	conn.PlanCache.WithEnabled(true)
 
 	var ok string
-	a.Nil(conn.Invoke(OptCachedPlanKey("status")).Query("select 'ok!'").Scan(&ok))
+	_, err = conn.Invoke(OptCachedPlanKey("status")).Query("select 'ok!'").Scan(&ok)
+	a.Nil(err)
 	a.Equal("ok!", ok)
 
-	a.Nil(conn.Invoke(OptCachedPlanKey("status")).Query("select 'ok!'").Scan(&ok))
+	_, err = conn.Invoke(OptCachedPlanKey("status")).Query("select 'ok!'").Scan(&ok)
+	a.Nil(err)
 	a.Equal("ok!", ok)
 
 	a.True(conn.PlanCache.HasStatement("status"))
@@ -118,7 +120,7 @@ func TestExec(t *testing.T) {
 	a.Nil(err)
 	defer tx.Rollback()
 
-	_, err = defaultDB().Invoke(OptTx(tx)).Exec("select 'ok!'")
+	err = defaultDB().Invoke(OptTx(tx)).Exec("select 'ok!'")
 	a.Nil(err)
 }
 
@@ -139,23 +141,23 @@ func TestConnectionInvalidatesBadCachedStatements(t *testing.T) {
 	queryStatement := `SELECT * from state_invalidation`
 
 	defer func() {
-		_, err = conn.Exec(dropTableStatement)
+		err = conn.Exec(dropTableStatement)
 		assert.Nil(err)
 	}()
 
-	_, err = conn.Exec(createTableStatement)
+	err = conn.Exec(createTableStatement)
 	assert.Nil(err)
 
-	_, err = conn.Exec(insertStatement, 1, "Foo")
+	err = conn.Exec(insertStatement, 1, "Foo")
 	assert.Nil(err)
 
-	_, err = conn.Exec(insertStatement, 2, "Bar")
+	err = conn.Exec(insertStatement, 2, "Bar")
 	assert.Nil(err)
 
 	_, err = conn.Query(queryStatement).Any()
 	assert.Nil(err)
 
-	_, err = conn.Exec(alterTableStatement)
+	err = conn.Exec(alterTableStatement)
 	assert.Nil(err)
 
 	// normally this would result in a busted cached query plan.

--- a/db/connection_test.go
+++ b/db/connection_test.go
@@ -66,15 +66,15 @@ func TestConnectionStatementCacheExecute(t *testing.T) {
 	a.Nil(conn.Open())
 	defer conn.Close()
 	conn.PlanCache.WithEnabled(true)
-	err = conn.Exec("select 'ok!'")
+	err = IgnoreExecResult(conn.Exec("select 'ok!'"))
 	a.Nil(err)
-	err = conn.Exec("select 'ok!'")
+	err = IgnoreExecResult(conn.Exec("select 'ok!'"))
 	a.Nil(err)
 	a.False(conn.PlanCache.HasStatement("select 'ok!'"))
 
-	err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
+	err = IgnoreExecResult(conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'"))
 	a.Nil(err)
-	err = conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'")
+	err = IgnoreExecResult(conn.Invoke(OptCachedPlanKey("ping")).Exec("select 'ok!'"))
 	a.Nil(err)
 	a.True(conn.PlanCache.HasStatement("ping"))
 }
@@ -120,7 +120,7 @@ func TestExec(t *testing.T) {
 	a.Nil(err)
 	defer tx.Rollback()
 
-	err = defaultDB().Invoke(OptTx(tx)).Exec("select 'ok!'")
+	err = IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("select 'ok!'"))
 	a.Nil(err)
 }
 
@@ -141,23 +141,23 @@ func TestConnectionInvalidatesBadCachedStatements(t *testing.T) {
 	queryStatement := `SELECT * from state_invalidation`
 
 	defer func() {
-		err = conn.Exec(dropTableStatement)
+		err = IgnoreExecResult(conn.Exec(dropTableStatement))
 		assert.Nil(err)
 	}()
 
-	err = conn.Exec(createTableStatement)
+	err = IgnoreExecResult(conn.Exec(createTableStatement))
 	assert.Nil(err)
 
-	err = conn.Exec(insertStatement, 1, "Foo")
+	err = IgnoreExecResult(conn.Exec(insertStatement, 1, "Foo"))
 	assert.Nil(err)
 
-	err = conn.Exec(insertStatement, 2, "Bar")
+	err = IgnoreExecResult(conn.Exec(insertStatement, 2, "Bar"))
 	assert.Nil(err)
 
 	_, err = conn.Query(queryStatement).Any()
 	assert.Nil(err)
 
-	err = conn.Exec(alterTableStatement)
+	err = IgnoreExecResult(conn.Exec(alterTableStatement))
 	assert.Nil(err)
 
 	// normally this would result in a busted cached query plan.

--- a/db/invocation.go
+++ b/db/invocation.go
@@ -750,7 +750,7 @@ func (i *Invocation) AutoValues(autos *ColumnCollection) []interface{} {
 // SetAutos sets the automatic values for a given object.
 func (i *Invocation) SetAutos(object DatabaseMapped, autos *ColumnCollection, autoValues []interface{}) (err error) {
 	for index := 0; index < len(autoValues); index++ {
-		err = autos.Columns()[index].SetValue(object, autoValues[index], false)
+		err = autos.Columns()[index].SetValue(object, autoValues[index])
 		if err != nil {
 			err = Error(err)
 			return

--- a/db/invocation.go
+++ b/db/invocation.go
@@ -38,14 +38,8 @@ func (i *Invocation) Prepare(statement string) (stmt *sql.Stmt, err error) {
 	return
 }
 
-// Exec executes a sql statement with a given set of arguments.
-func (i *Invocation) Exec(statement string, args ...interface{}) (err error) {
-	_, err = i.ExecStats(statement, args...)
-	return
-}
-
-// ExecStats executes a sql statement with a given set of arguments and returns the rows affected.
-func (i *Invocation) ExecStats(statement string, args ...interface{}) (rowsAffected int64, err error) {
+// Exec executes a sql statement with a given set of arguments and returns the rows affected.
+func (i *Invocation) Exec(statement string, args ...interface{}) (res sql.Result, err error) {
 	var stmt *sql.Stmt
 	statement, err = i.Start(statement)
 	defer func() { err = i.Finish(statement, recover(), err) }()
@@ -60,14 +54,11 @@ func (i *Invocation) ExecStats(statement string, args ...interface{}) (rowsAffec
 	}
 	defer func() { err = i.CloseStatement(stmt, err) }()
 
-	res, err := stmt.ExecContext(i.Context, args...)
+	res, err = stmt.ExecContext(i.Context, args...)
 	if err != nil {
 		err = Error(err)
 		return
 	}
-	// The error here is intentionally ignored. Postgres supports this. We'd need to revisit swallowing this error
-	// for other drivers
-	rowsAffected, _ = res.RowsAffected()
 	return
 }
 

--- a/db/invocation_test.go
+++ b/db/invocation_test.go
@@ -34,13 +34,11 @@ func secondArgErr(_ interface{}, err error) error {
 }
 
 func createJSONTestTable(tx *sql.Tx) error {
-	_, err := defaultDB().Invoke(OptTx(tx)).Exec("create table json_test (id serial primary key, name varchar(255), not_null json, nullable json)")
-	return err
+	return defaultDB().Invoke(OptTx(tx)).Exec("create table json_test (id serial primary key, name varchar(255), not_null json, nullable json)")
 }
 
 func dropJSONTextTable(tx *sql.Tx) error {
-	_, err := defaultDB().Invoke(OptTx(tx)).Exec("drop table if exists json_test")
-	return err
+	return defaultDB().Invoke(OptTx(tx)).Exec("drop table if exists json_test")
 }
 
 func TestInvocationJSONNulls(t *testing.T) {
@@ -90,7 +88,7 @@ func TestInvocationJSONNulls(t *testing.T) {
 	assert.True(any, "we should have written a sql null, not a literal string 'null'")
 
 	// set it to literal 'null' to test this is backward compatible
-	_, err = defaultDB().Invoke(OptTx(tx)).Exec("update json_test set nullable = 'null' where id = $1", obj1.ID)
+	err = defaultDB().Invoke(OptTx(tx)).Exec("update json_test set nullable = 'null' where id = $1", obj1.ID)
 	assert.Nil(err)
 
 	var verify2 jsonTest
@@ -119,7 +117,7 @@ func TestInvocationCreateRepeatInTx(t *testing.T) {
 	assert.Nil(err)
 	defer tx.Rollback()
 
-	assert.Nil(secondArgErr(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS unique_obj (id int not null primary key, name varchar)")))
+	assert.Nil(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS unique_obj (id int not null primary key, name varchar)"))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&uniqueObj{ID: 1, Name: "one"}))
 	var verify uniqueObj
 	assert.Nil(secondArgErr(defaultDB().Invoke(OptTx(tx)).Get(&verify, 1)))
@@ -310,7 +308,7 @@ func TestInvocationUUIDs(t *testing.T) {
 	assert.Nil(err)
 	defer tx.Rollback()
 
-	assert.Nil(secondArgErr(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS uuid_test (id uuid not null, name varchar(255) not null)")))
+	assert.Nil(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS uuid_test (id uuid not null, name varchar(255) not null)"))
 
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&uuidTest{ID: uuid.V4(), Name: "foo"}))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&uuidTest{ID: uuid.V4(), Name: "foo2"}))
@@ -356,7 +354,7 @@ func TestInlineMeta(t *testing.T) {
 
 	id0 := uuid.V4()
 	id1 := uuid.V4()
-	assert.Nil(secondArgErr(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS embedded_test (id uuid not null primary key, timestamp_utc timestamp not null, name varchar(255) not null)")))
+	assert.Nil(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS embedded_test (id uuid not null primary key, timestamp_utc timestamp not null, name varchar(255) not null)"))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&embeddedTest{EmbeddedTestMeta: EmbeddedTestMeta{ID: id0, TimestampUTC: time.Now().UTC()}, Name: "foo"}))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&embeddedTest{EmbeddedTestMeta: EmbeddedTestMeta{ID: id1, TimestampUTC: time.Now().UTC()}, Name: "foo2"}))
 
@@ -392,7 +390,7 @@ func TestInvocationStatementInterceptor(t *testing.T) {
 	}))
 	assert.NotNil(invocation.StatementInterceptor)
 
-	_, err = invocation.Exec("select 'ok!'")
+	err = invocation.Exec("select 'ok!'")
 	assert.NotNil(err)
 	assert.Equal("only a test", err.Error())
 }
@@ -739,9 +737,9 @@ func TestInvocationEarlyExitOnError(t *testing.T) {
 	defer tx.Rollback()
 
 	i := defaultDB().Invoke(OptTx(tx))
-	assert.Nil(secondArgErr(i.Exec("select 1")))
+	assert.Nil(i.Exec("select 1"))
 
 	i.Err = fmt.Errorf("this is a test")
-	_, err = i.Exec("select 1")
+	err = i.Exec("select 1")
 	assert.Equal("this is a test", err.Error())
 }

--- a/db/invocation_test.go
+++ b/db/invocation_test.go
@@ -34,11 +34,11 @@ func secondArgErr(_ interface{}, err error) error {
 }
 
 func createJSONTestTable(tx *sql.Tx) error {
-	return defaultDB().Invoke(OptTx(tx)).Exec("create table json_test (id serial primary key, name varchar(255), not_null json, nullable json)")
+	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("create table json_test (id serial primary key, name varchar(255), not_null json, nullable json)"))
 }
 
 func dropJSONTextTable(tx *sql.Tx) error {
-	return defaultDB().Invoke(OptTx(tx)).Exec("drop table if exists json_test")
+	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("drop table if exists json_test"))
 }
 
 func TestInvocationJSONNulls(t *testing.T) {
@@ -88,7 +88,7 @@ func TestInvocationJSONNulls(t *testing.T) {
 	assert.True(any, "we should have written a sql null, not a literal string 'null'")
 
 	// set it to literal 'null' to test this is backward compatible
-	err = defaultDB().Invoke(OptTx(tx)).Exec("update json_test set nullable = 'null' where id = $1", obj1.ID)
+	err = IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("update json_test set nullable = 'null' where id = $1", obj1.ID))
 	assert.Nil(err)
 
 	var verify2 jsonTest
@@ -117,7 +117,7 @@ func TestInvocationCreateRepeatInTx(t *testing.T) {
 	assert.Nil(err)
 	defer tx.Rollback()
 
-	assert.Nil(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS unique_obj (id int not null primary key, name varchar)"))
+	assert.Nil(IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS unique_obj (id int not null primary key, name varchar)")))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&uniqueObj{ID: 1, Name: "one"}))
 	var verify uniqueObj
 	assert.Nil(secondArgErr(defaultDB().Invoke(OptTx(tx)).Get(&verify, 1)))
@@ -134,10 +134,10 @@ func TestInvocationExecError(t *testing.T) {
 	assert.Nil(err)
 	conn.PlanCache.WithEnabled(false)
 	assert.Nil(conn.Open())
-	assert.NotNil(conn.Invoke().Exec("not a select"))
+	assert.NotNil(IgnoreExecResult(conn.Invoke().Exec("not a select")))
 	conn.PlanCache.WithEnabled(true)
-	assert.NotNil(conn.Invoke().Exec("not a select"))
-	assert.NotNil(conn.Invoke(OptCachedPlanKey("exec_error_test")).Exec("not a select"))
+	assert.NotNil(IgnoreExecResult(conn.Invoke().Exec("not a select")))
+	assert.NotNil(IgnoreExecResult(conn.Invoke(OptCachedPlanKey("exec_error_test")).Exec("not a select")))
 }
 
 type modelTableNameError struct {
@@ -308,7 +308,7 @@ func TestInvocationUUIDs(t *testing.T) {
 	assert.Nil(err)
 	defer tx.Rollback()
 
-	assert.Nil(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS uuid_test (id uuid not null, name varchar(255) not null)"))
+	assert.Nil(IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS uuid_test (id uuid not null, name varchar(255) not null)")))
 
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&uuidTest{ID: uuid.V4(), Name: "foo"}))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&uuidTest{ID: uuid.V4(), Name: "foo2"}))
@@ -354,7 +354,7 @@ func TestInlineMeta(t *testing.T) {
 
 	id0 := uuid.V4()
 	id1 := uuid.V4()
-	assert.Nil(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS embedded_test (id uuid not null primary key, timestamp_utc timestamp not null, name varchar(255) not null)"))
+	assert.Nil(IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec("CREATE TABLE IF NOT EXISTS embedded_test (id uuid not null primary key, timestamp_utc timestamp not null, name varchar(255) not null)")))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&embeddedTest{EmbeddedTestMeta: EmbeddedTestMeta{ID: id0, TimestampUTC: time.Now().UTC()}, Name: "foo"}))
 	assert.Nil(defaultDB().Invoke(OptTx(tx)).Create(&embeddedTest{EmbeddedTestMeta: EmbeddedTestMeta{ID: id1, TimestampUTC: time.Now().UTC()}, Name: "foo2"}))
 
@@ -390,7 +390,7 @@ func TestInvocationStatementInterceptor(t *testing.T) {
 	}))
 	assert.NotNil(invocation.StatementInterceptor)
 
-	err = invocation.Exec("select 'ok!'")
+	err = IgnoreExecResult(invocation.Exec("select 'ok!'"))
 	assert.NotNil(err)
 	assert.Equal("only a test", err.Error())
 }
@@ -737,9 +737,9 @@ func TestInvocationEarlyExitOnError(t *testing.T) {
 	defer tx.Rollback()
 
 	i := defaultDB().Invoke(OptTx(tx))
-	assert.Nil(i.Exec("select 1"))
+	assert.Nil(IgnoreExecResult(i.Exec("select 1")))
 
 	i.Err = fmt.Errorf("this is a test")
-	err = i.Exec("select 1")
+	err = IgnoreExecResult(i.Exec("select 1"))
 	assert.Equal("this is a test", err.Error())
 }

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -113,8 +113,7 @@ func (uo upsertObj) TableName() string {
 
 func createUpserObjectTable(tx *sql.Tx) error {
 	createSQL := `CREATE TABLE IF NOT EXISTS upsert_object (uuid varchar(255) primary key, timestamp_utc timestamp, category varchar(255));`
-	_, err := defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
-	return err
+	return defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
 }
 
 //------------------------------------------------------------------------------------------------
@@ -149,21 +148,17 @@ func createTable(tx *sql.Tx) error {
 		, pending boolean
 		, category varchar(255)
 	);`
-	i, err := defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
-	fmt.Printf("Count: %d", i)
-	return err
+	return defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
 }
 
 func dropTableIfExists(tx *sql.Tx) error {
 	dropSQL := `DROP TABLE IF EXISTS bench_object;`
-	_, err := defaultDB().Invoke(OptTx(tx)).Exec(dropSQL)
-	return err
+	return defaultDB().Invoke(OptTx(tx)).Exec(dropSQL)
 }
 
 func ensureUUIDExtension() error {
 	uuidCreate := `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
-	_, err := defaultDB().Exec(uuidCreate)
-	return err
+	return defaultDB().Exec(uuidCreate)
 }
 
 func createObject(index int, tx *sql.Tx) error {

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -113,7 +113,7 @@ func (uo upsertObj) TableName() string {
 
 func createUpserObjectTable(tx *sql.Tx) error {
 	createSQL := `CREATE TABLE IF NOT EXISTS upsert_object (uuid varchar(255) primary key, timestamp_utc timestamp, category varchar(255));`
-	return defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
+	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec(createSQL))
 }
 
 //------------------------------------------------------------------------------------------------
@@ -148,17 +148,17 @@ func createTable(tx *sql.Tx) error {
 		, pending boolean
 		, category varchar(255)
 	);`
-	return defaultDB().Invoke(OptTx(tx)).Exec(createSQL)
+	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec(createSQL))
 }
 
 func dropTableIfExists(tx *sql.Tx) error {
 	dropSQL := `DROP TABLE IF EXISTS bench_object;`
-	return defaultDB().Invoke(OptTx(tx)).Exec(dropSQL)
+	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec(dropSQL))
 }
 
 func ensureUUIDExtension() error {
 	uuidCreate := `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
-	return defaultDB().Exec(uuidCreate)
+	return IgnoreExecResult(defaultDB().Exec(uuidCreate))
 }
 
 func createObject(index int, tx *sql.Tx) error {

--- a/db/migration/action.go
+++ b/db/migration/action.go
@@ -22,7 +22,7 @@ func NoOp(_ context.Context, _ *db.Connection, _ *sql.Tx) error { return nil }
 func Statements(statements ...string) Action {
 	return func(ctx context.Context, c *db.Connection, tx *sql.Tx) (err error) {
 		for _, statement := range statements {
-			err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement)
+			err = db.IgnoreExecResult(c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement))
 			if err != nil {
 				return
 			}
@@ -35,7 +35,7 @@ func Statements(statements ...string) Action {
 // It can be used in lieu of Statements, when parameterization is needed
 func Exec(statement string, args ...interface{}) Action {
 	return func(ctx context.Context, c *db.Connection, tx *sql.Tx) (err error) {
-		err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement, args...)
+		err = db.IgnoreExecResult(c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement, args...))
 		return
 	}
 }

--- a/db/migration/action.go
+++ b/db/migration/action.go
@@ -22,7 +22,7 @@ func NoOp(_ context.Context, _ *db.Connection, _ *sql.Tx) error { return nil }
 func Statements(statements ...string) Action {
 	return func(ctx context.Context, c *db.Connection, tx *sql.Tx) (err error) {
 		for _, statement := range statements {
-			_, err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement)
+			err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement)
 			if err != nil {
 				return
 			}
@@ -35,7 +35,7 @@ func Statements(statements ...string) Action {
 // It can be used in lieu of Statements, when parameterization is needed
 func Exec(statement string, args ...interface{}) Action {
 	return func(ctx context.Context, c *db.Connection, tx *sql.Tx) (err error) {
-		_, err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement, args...)
+		err = c.Invoke(db.OptContext(ctx), db.OptTx(tx)).Exec(statement, args...)
 		return
 	}
 }

--- a/db/migration/data_file_reader.go
+++ b/db/migration/data_file_reader.go
@@ -94,7 +94,7 @@ func (dfr *DataFileReader) Action(ctx context.Context, c *db.Connection, tx *sql
 				continue
 			}
 
-			err = c.Invoke(db.OptTx(tx)).Exec(line)
+			err = db.IgnoreExecResult(c.Invoke(db.OptTx(tx)).Exec(line))
 			if err != nil {
 				return
 			}

--- a/db/migration/data_file_reader.go
+++ b/db/migration/data_file_reader.go
@@ -94,7 +94,7 @@ func (dfr *DataFileReader) Action(ctx context.Context, c *db.Connection, tx *sql
 				continue
 			}
 
-			_, err = c.Invoke(db.OptTx(tx)).Exec(line)
+			err = c.Invoke(db.OptTx(tx)).Exec(line)
 			if err != nil {
 				return
 			}

--- a/db/migration/data_file_reader_test.go
+++ b/db/migration/data_file_reader_test.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/blend/go-sdk/db"
-	"github.com/blend/go-sdk/logger"
 	"io"
 	"testing"
+
+	"github.com/blend/go-sdk/db"
+	"github.com/blend/go-sdk/logger"
 
 	"github.com/blend/go-sdk/assert"
 )
@@ -146,7 +147,7 @@ func TestDataFileReaderAction(t *testing.T) {
 	a := assert.New(t)
 	conn := getSchemaConnection(db.DefaultSchema, a)
 	testSchemaName := buildTestSchemaName()
-	_, err := conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	err := conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 	a.Nil(err)
 	dfr := ReadDataFile("./testdata/data_file_reader_test.sql")
 	s := New(OptLog(logger.None()), OptGroups(createDataFileMigrations(testSchemaName)...))
@@ -156,7 +157,7 @@ func TestDataFileReaderAction(t *testing.T) {
 			c = defaultDB()
 		}
 		// pq can't parameterize Drop
-		_, err := c.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		err := c.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), conn)
@@ -171,8 +172,10 @@ func TestDataFileReaderAction(t *testing.T) {
 	a.Nil(err)
 
 	var count int
-	err = conn.Query("Select count(1) from test_table_one").Scan(&count)
+	var found bool
+	found, err = conn.Query("Select count(1) from test_table_one").Scan(&count)
 	a.Nil(err)
+	a.True(found)
 	a.Equal(3, count)
 
 	var data []Data
@@ -193,7 +196,7 @@ func createDataFileMigrations(testSchemaName string) []*Group {
 				Actions(
 					// pq can't parameterize Create
 					func(i context.Context, connection *db.Connection, tx *sql.Tx) error {
-						_, err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
+						err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
 						if err != nil {
 							return err
 						}

--- a/db/migration/data_file_reader_test.go
+++ b/db/migration/data_file_reader_test.go
@@ -147,7 +147,7 @@ func TestDataFileReaderAction(t *testing.T) {
 	a := assert.New(t)
 	conn := getSchemaConnection(db.DefaultSchema, a)
 	testSchemaName := buildTestSchemaName()
-	err := conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	err := db.IgnoreExecResult(conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName)))
 	a.Nil(err)
 	dfr := ReadDataFile("./testdata/data_file_reader_test.sql")
 	s := New(OptLog(logger.None()), OptGroups(createDataFileMigrations(testSchemaName)...))
@@ -157,7 +157,7 @@ func TestDataFileReaderAction(t *testing.T) {
 			c = defaultDB()
 		}
 		// pq can't parameterize Drop
-		err := c.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		err := db.IgnoreExecResult(c.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName)))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), conn)
@@ -196,7 +196,7 @@ func createDataFileMigrations(testSchemaName string) []*Group {
 				Actions(
 					// pq can't parameterize Create
 					func(i context.Context, connection *db.Connection, tx *sql.Tx) error {
-						err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
+						err := db.IgnoreExecResult(connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName)))
 						if err != nil {
 							return err
 						}

--- a/db/migration/guard_predicates_test.go
+++ b/db/migration/guard_predicates_test.go
@@ -43,7 +43,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE table_test_foo (id serial not null primary key, something varchar(32) not null)")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE table_test_foo (id serial not null primary key, something varchar(32) not null)"))
 	assert.Nil(err)
 
 	didRun = false
@@ -60,7 +60,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD CONSTRAINT constraint_foo UNIQUE (something)")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD CONSTRAINT constraint_foo UNIQUE (something)"))
 	assert.Nil(err)
 
 	didRun = false
@@ -77,7 +77,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD COLUMN created_foo timestamp not null")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD COLUMN created_foo timestamp not null"))
 	assert.Nil(err)
 
 	didRun = false
@@ -94,7 +94,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_foo ON table_test_foo(created_foo DESC)")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_foo ON table_test_foo(created_foo DESC)"))
 	assert.Nil(err)
 
 	didRun = false
@@ -115,7 +115,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	iName := "index_bar"
 	tName := "table_test_bar"
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE SCHEMA schema_test_bar")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE SCHEMA schema_test_bar"))
 	assert.Nil(err)
 
 	var didRun bool
@@ -132,7 +132,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE schema_test_bar.table_test_bar (id serial not null primary key, something varchar(32) not null, created timestamp not null)")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE schema_test_bar.table_test_bar (id serial not null primary key, something varchar(32) not null, created timestamp not null)"))
 	assert.Nil(err)
 
 	didRun = false
@@ -149,7 +149,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD CONSTRAINT constraint_bar UNIQUE (something)")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD CONSTRAINT constraint_bar UNIQUE (something)"))
 	assert.Nil(err)
 
 	didRun = false
@@ -166,7 +166,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD COLUMN created_bar timestamp not null")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD COLUMN created_bar timestamp not null"))
 	assert.Nil(err)
 
 	didRun = false
@@ -183,7 +183,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_bar ON schema_test_bar.table_test_bar(created_bar DESC)")
+	err = db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_bar ON schema_test_bar.table_test_bar(created_bar DESC)"))
 	assert.Nil(err)
 
 	didRun = false

--- a/db/migration/guard_predicates_test.go
+++ b/db/migration/guard_predicates_test.go
@@ -3,9 +3,10 @@ package migration
 import (
 	"context"
 	"database/sql"
+	"testing"
+
 	"github.com/blend/go-sdk/assert"
 	"github.com/blend/go-sdk/db"
-	"testing"
 )
 
 func TestGuardPredicatesReal(t *testing.T) {
@@ -42,7 +43,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE table_test_foo (id serial not null primary key, something varchar(32) not null)")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE table_test_foo (id serial not null primary key, something varchar(32) not null)")
 	assert.Nil(err)
 
 	didRun = false
@@ -59,7 +60,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD CONSTRAINT constraint_foo UNIQUE (something)")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD CONSTRAINT constraint_foo UNIQUE (something)")
 	assert.Nil(err)
 
 	didRun = false
@@ -76,7 +77,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD COLUMN created_foo timestamp not null")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE table_test_foo ADD COLUMN created_foo timestamp not null")
 	assert.Nil(err)
 
 	didRun = false
@@ -93,7 +94,7 @@ func TestGuardPredicatesReal(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_foo ON table_test_foo(created_foo DESC)")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_foo ON table_test_foo(created_foo DESC)")
 	assert.Nil(err)
 
 	didRun = false
@@ -114,7 +115,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	iName := "index_bar"
 	tName := "table_test_bar"
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE SCHEMA schema_test_bar")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE SCHEMA schema_test_bar")
 	assert.Nil(err)
 
 	var didRun bool
@@ -131,7 +132,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE schema_test_bar.table_test_bar (id serial not null primary key, something varchar(32) not null, created timestamp not null)")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE TABLE schema_test_bar.table_test_bar (id serial not null primary key, something varchar(32) not null, created timestamp not null)")
 	assert.Nil(err)
 
 	didRun = false
@@ -148,7 +149,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD CONSTRAINT constraint_bar UNIQUE (something)")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD CONSTRAINT constraint_bar UNIQUE (something)")
 	assert.Nil(err)
 
 	didRun = false
@@ -165,7 +166,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD COLUMN created_bar timestamp not null")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("ALTER TABLE schema_test_bar.table_test_bar ADD COLUMN created_bar timestamp not null")
 	assert.Nil(err)
 
 	didRun = false
@@ -182,7 +183,7 @@ func TestGuardPredicatsRealSchema(t *testing.T) {
 	assert.Nil(err)
 	assert.True(didRun)
 
-	_, err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_bar ON schema_test_bar.table_test_bar(created_bar DESC)")
+	err = defaultDB().Invoke(db.OptTx(tx)).Exec("CREATE INDEX index_bar ON schema_test_bar.table_test_bar(created_bar DESC)")
 	assert.Nil(err)
 
 	didRun = false

--- a/db/migration/predicates_test.go
+++ b/db/migration/predicates_test.go
@@ -33,8 +33,7 @@ func createTestTable(tableName string, tx *sql.Tx) error {
 
 func insertTestValue(tableName string, id int, name string, tx *sql.Tx) error {
 	body := fmt.Sprintf("INSERT INTO %s (id, name) VALUES ($1, $2);", tableName)
-	_, err := defaultDB().Invoke(db.OptTx(tx)).Exec(body, id, name)
-	return err
+	return defaultDB().Invoke(db.OptTx(tx)).Exec(body, id, name)
 }
 
 func createTestColumn(tableName, columnName string, tx *sql.Tx) error {

--- a/db/migration/predicates_test.go
+++ b/db/migration/predicates_test.go
@@ -33,7 +33,7 @@ func createTestTable(tableName string, tx *sql.Tx) error {
 
 func insertTestValue(tableName string, id int, name string, tx *sql.Tx) error {
 	body := fmt.Sprintf("INSERT INTO %s (id, name) VALUES ($1, $2);", tableName)
-	return defaultDB().Invoke(db.OptTx(tx)).Exec(body, id, name)
+	return db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec(body, id, name))
 }
 
 func createTestColumn(tableName, columnName string, tx *sql.Tx) error {

--- a/db/migration/suite_test.go
+++ b/db/migration/suite_test.go
@@ -14,12 +14,12 @@ import (
 func TestSuite_Apply(t *testing.T) {
 	a := assert.New(t)
 	testSchemaName := buildTestSchemaName()
-	err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	err := db.IgnoreExecResult(defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName)))
 	a.Nil(err)
 	s := New(OptLog(logger.None()), OptGroups(createTestMigrations(testSchemaName)...))
 	defer func() {
 		// pq can't parameterize Drop
-		err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		err := db.IgnoreExecResult(defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName)))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), defaultDB())
@@ -39,13 +39,13 @@ func TestSuite_Apply(t *testing.T) {
 func TestSuite_ApplyFails(t *testing.T) {
 	a := assert.New(t)
 	testSchemaName := buildTestSchemaName()
-	err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	err := db.IgnoreExecResult(defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName)))
 	a.Nil(err)
 	s := New(OptLog(logger.None()), OptGroups(createTestMigrations(testSchemaName)...))
 	s.Groups = append(s.Groups, NewGroupWithActions(NewStep(Always(), Actions(Statements(`INSERT INTO tab_not_exists VALUES (1, 'blah', CURRENT_TIMESTAMP');`)))))
 	defer func() {
 		// pq can't parameterize Drop
-		err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		err := db.IgnoreExecResult(defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName)))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), defaultDB())
@@ -70,7 +70,7 @@ func createTestMigrations(testSchemaName string) []*Group {
 				Actions(
 					// pq can't parameterize Create
 					func(i context.Context, connection *db.Connection, tx *sql.Tx) error {
-						err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
+						err := db.IgnoreExecResult(connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName)))
 						if err != nil {
 							return err
 						}

--- a/db/migration/suite_test.go
+++ b/db/migration/suite_test.go
@@ -4,21 +4,22 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"testing"
+
 	"github.com/blend/go-sdk/assert"
 	"github.com/blend/go-sdk/db"
 	"github.com/blend/go-sdk/logger"
-	"testing"
 )
 
 func TestSuite_Apply(t *testing.T) {
 	a := assert.New(t)
 	testSchemaName := buildTestSchemaName()
-	_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 	a.Nil(err)
 	s := New(OptLog(logger.None()), OptGroups(createTestMigrations(testSchemaName)...))
 	defer func() {
 		// pq can't parameterize Drop
-		_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), defaultDB())
@@ -38,13 +39,13 @@ func TestSuite_Apply(t *testing.T) {
 func TestSuite_ApplyFails(t *testing.T) {
 	a := assert.New(t)
 	testSchemaName := buildTestSchemaName()
-	_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+	err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 	a.Nil(err)
 	s := New(OptLog(logger.None()), OptGroups(createTestMigrations(testSchemaName)...))
 	s.Groups = append(s.Groups, NewGroupWithActions(NewStep(Always(), Actions(Statements(`INSERT INTO tab_not_exists VALUES (1, 'blah', CURRENT_TIMESTAMP');`)))))
 	defer func() {
 		// pq can't parameterize Drop
-		_, err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
+		err := defaultDB().Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", testSchemaName))
 		a.Nil(err)
 	}()
 	err = s.Apply(context.Background(), defaultDB())
@@ -69,7 +70,7 @@ func createTestMigrations(testSchemaName string) []*Group {
 				Actions(
 					// pq can't parameterize Create
 					func(i context.Context, connection *db.Connection, tx *sql.Tx) error {
-						_, err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
+						err := connection.Exec(fmt.Sprintf("CREATE SCHEMA %s;", testSchemaName))
 						if err != nil {
 							return err
 						}

--- a/db/populate.go
+++ b/db/populate.go
@@ -9,14 +9,13 @@ import (
 
 // PopulateEmpty populates all the column fields of a struct with empty value
 func PopulateEmpty(object interface{}, cols *ColumnCollection) {
-	var columnLookup = cols.Lookup()
-	for _, v := range columnLookup {
+	for _, v := range cols.columns {
 		v.SetZero(object)
 	}
 }
 
 // PopulateByName sets the values of an object from the values of a sql.Rows object using column names.
-func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, clearEmpty bool) error {
+func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, resetRowEmpty bool) error {
 	rowColumns, err := row.Columns()
 	if err != nil {
 		return Error(err)
@@ -34,7 +33,7 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, clearE
 	}
 
 	err = row.Scan(values...)
-	if clearEmpty {
+	if resetRowEmpty {
 		PopulateEmpty(object, cols)
 	}
 	if err != nil {
@@ -47,7 +46,7 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, clearE
 	for i, v := range values {
 		colName = rowColumns[i]
 		if field, ok = columnLookup[colName]; ok {
-			err = field.SetValue(object, v, clearEmpty)
+			err = field.SetValue(object, v, resetRowEmpty)
 			if err != nil {
 				return ex.New(Error(err), ex.OptMessagef("column: %s", colName))
 			}

--- a/db/populate.go
+++ b/db/populate.go
@@ -59,11 +59,12 @@ func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection)
 		return Error(err)
 	}
 
+	objectValue := reflect.ValueOf(object)
 	columns := cols.Columns()
 	var field Column
 	for i, v := range values {
 		field = columns[i]
-		if err = field.SetValue(object, v); err != nil {
+		if err = field.SetValueReflected(objectValue, v); err != nil {
 			err = ex.New(err)
 			return
 		}

--- a/db/populate.go
+++ b/db/populate.go
@@ -33,10 +33,12 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection) error 
 	var colName string
 	var field *Column
 	var ok bool
+
+	objectValue := ReflectValue(object)
 	for i, v := range values {
 		colName = rowColumns[i]
 		if field, ok = columnLookup[colName]; ok {
-			err = field.SetValue(object, v)
+			err = field.SetValueReflected(objectValue, v)
 			if err != nil {
 				return err
 			}
@@ -59,7 +61,7 @@ func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection)
 		return Error(err)
 	}
 
-	objectValue := reflect.ValueOf(object)
+	objectValue := ReflectValue(object)
 	columns := cols.Columns()
 	var field Column
 	for i, v := range values {

--- a/db/populate.go
+++ b/db/populate.go
@@ -15,7 +15,7 @@ func PopulateEmpty(object interface{}, cols *ColumnCollection) {
 }
 
 // PopulateByName sets the values of an object from the values of a sql.Rows object using column names.
-func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, resetRowEmpty bool) error {
+func PopulateByName(object interface{}, row Rows, cols *ColumnCollection) error {
 	rowColumns, err := row.Columns()
 	if err != nil {
 		return Error(err)
@@ -33,9 +33,6 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, resetR
 	}
 
 	err = row.Scan(values...)
-	if resetRowEmpty {
-		PopulateEmpty(object, cols)
-	}
 	if err != nil {
 		return Error(err)
 	}
@@ -46,7 +43,7 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, resetR
 	for i, v := range values {
 		colName = rowColumns[i]
 		if field, ok = columnLookup[colName]; ok {
-			err = field.SetValue(object, v, resetRowEmpty)
+			err = field.SetValue(object, v)
 			if err != nil {
 				return ex.New(Error(err), ex.OptMessagef("column: %s", colName))
 			}
@@ -59,15 +56,11 @@ func PopulateByName(object interface{}, row Rows, cols *ColumnCollection, resetR
 // PopulateInOrder sets the values of an object in order from a sql.Rows object.
 // Only use this method if you're certain of the column order. It is faster than populateByName.
 // Optionally if your object implements Populatable this process will be skipped completely, which is even faster.
-func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection, clearEmpty bool) (err error) {
+func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection) (err error) {
 	var values = make([]interface{}, cols.Len())
 
 	for i, col := range cols.Columns() {
 		initColumnValue(i, values, &col)
-	}
-
-	if clearEmpty {
-		PopulateEmpty(object, cols)
 	}
 	if err = row.Scan(values...); err != nil {
 		return Error(err)
@@ -77,7 +70,7 @@ func PopulateInOrder(object DatabaseMapped, row Scanner, cols *ColumnCollection,
 	var field Column
 	for i, v := range values {
 		field = columns[i]
-		if err = field.SetValue(object, v, clearEmpty); err != nil {
+		if err = field.SetValue(object, v); err != nil {
 			err = ex.New(err)
 			return
 		}

--- a/db/query.go
+++ b/db/query.go
@@ -120,14 +120,13 @@ func (q *Query) Out(object interface{}) (found bool, err error) {
 		if err != nil {
 			return
 		}
-	} else if _, ok := object.(Populatable); !ok {
-		PopulateEmpty(object, columnMeta)
+	} else if err = Zero(object); err != nil {
+		return
 	}
 
 	if q.Rows.Next() {
 		err = Error(ErrTooManyRows)
 	}
-
 	return
 }
 

--- a/db/query.go
+++ b/db/query.go
@@ -35,7 +35,7 @@ func (q *Query) Execute() (rows *sql.Rows, err error) {
 }
 
 // Any returns if there are any results for the query.
-func (q *Query) Any() (hasRows bool, err error) {
+func (q *Query) Any() (found bool, err error) {
 	defer func() { err = q.finish(recover(), err) }()
 
 	q.Rows, q.Err = q.query()
@@ -45,12 +45,12 @@ func (q *Query) Any() (hasRows bool, err error) {
 	}
 	defer func() { err = ex.Nest(err, q.Rows.Close()) }()
 
-	hasRows = q.Rows.Next()
+	found = q.Rows.Next()
 	return
 }
 
 // None returns if there are no results for the query.
-func (q *Query) None() (hasRows bool, err error) {
+func (q *Query) None() (notFound bool, err error) {
 	defer func() { err = q.finish(recover(), err) }()
 
 	q.Rows, q.Err = q.query()
@@ -59,12 +59,14 @@ func (q *Query) None() (hasRows bool, err error) {
 		return
 	}
 	defer func() { err = ex.Nest(err, Error(q.Rows.Close())) }()
-	hasRows = !q.Rows.Next()
+	notFound = !q.Rows.Next()
 	return
 }
 
 // Scan writes the results to a given set of local variables.
-func (q *Query) Scan(args ...interface{}) (err error) {
+// It returns if the query produced a row, and returns `ErrTooManyRows` if there
+// are multiple row results.
+func (q *Query) Scan(args ...interface{}) (found bool, err error) {
 	defer func() { err = q.finish(recover(), err) }()
 
 	q.Rows, q.Err = q.query()
@@ -75,66 +77,34 @@ func (q *Query) Scan(args ...interface{}) (err error) {
 	defer func() { err = ex.Nest(err, Error(q.Rows.Close())) }()
 
 	if q.Rows.Next() {
+		found = true
 		if err = q.Rows.Scan(args...); err != nil {
 			err = Error(err)
 			return
 		}
 	}
-
-	return
-}
-
-// Out writes the query result to a single object via. reflection mapping. If there is more than one result, the first
-// result is mapped to to object, and ErrTooManyRows is returned. Unlike Into(), if a field on the stuct is not present
-// or is an "empty" value in the result set, Out clears the field on object it is populating. In short Out maps the
-// output of your query into object as "exactly" as possible. Where you can, prefer Out over Into
-func (q *Query) Out(object interface{}) (found bool, err error) {
-	return q.populateImpl(object, true)
-}
-
-// Into writes the query result to a single object via. reflection mapping. If there is more than one result, the first
-// result is mapped to to object, and ErrTooManyRows is returned. Into is different than Out, in that is DOES NOT change
-// struct fields on object that are empty in the result set. If a result field is null the value that was present in
-// object is maintained. If you need multiple queries to fill up your object struct, you should be using Into()
-func (q *Query) Into(object interface{}) (found bool, err error) {
-	return q.populateImpl(object, false)
-}
-
-func (q *Query) populateImpl(object interface{}, clearEmpty bool) (found bool, err error) {
-	defer func() { err = q.finish(recover(), err) }()
-	q.Rows, q.Err = q.query()
-	if q.Err != nil {
-		err = q.Err
-		return
-	}
-	defer func() { err = ex.Nest(err, Error(q.Rows.Close())) }()
-
-	sliceType := ReflectType(object)
-	if sliceType.Kind() != reflect.Struct {
-		err = Error(ErrDestinationNotStruct)
-		return
-	}
-
-	columnMeta := CachedColumnCollectionFromInstance(object)
-	if q.Rows.Next() {
-		found = true
-		if populatable, ok := object.(Populatable); ok {
-			err = populatable.Populate(q.Rows)
-		} else {
-			err = PopulateByName(object, q.Rows, columnMeta, clearEmpty)
-		}
-		if err != nil {
-			return
-		}
-	} else if _, ok := object.(Populatable); !ok {
-		PopulateEmpty(object, columnMeta)
-	}
-
 	if q.Rows.Next() {
 		err = Error(ErrTooManyRows)
 	}
 
 	return
+}
+
+// ReadInto writes the query result to a single object via. reflection mapping. If there is more than one result, the first
+// result is mapped to to object, and ErrTooManyRows is returned. Unlike Out(), if a field on the stuct is not present
+// or is an "empty" value in the result set, ReadInto() clears the field on object it is populating. In short ReadInto() maps the
+// output of your query into object as "exactly" as possible. Where you can, prefer ReadInto() over Out().
+// If you need multiple queries to fill up your object struct, you should be using Out().
+func (q *Query) ReadInto(object interface{}) (found bool, err error) {
+	return q.populate(object, true)
+}
+
+// Out writes the query result to a single object via. reflection mapping. If there is more than one result, the first
+// result is mapped to to object, and ErrTooManyRows is returned. Out() is different than ReadInto(), in that is DOES NOT change
+// struct fields on object that are empty in the result set. If a result field is null the value that was present in
+// object is maintained.
+func (q *Query) Out(object interface{}) (found bool, err error) {
+	return q.populate(object, false)
 }
 
 // OutMany writes the query results to a slice of objects.
@@ -159,14 +129,13 @@ func (q *Query) OutMany(collection interface{}) (err error) {
 	v := makeNew(sliceInnerType)
 	meta := CachedColumnCollectionFromType(newColumnCacheKey(sliceInnerType), sliceInnerType)
 
-	isPopulatable := isPopulatable(v)
+	isPopulatable := IsPopulatable(v)
 
-	didSetRows := false
+	var didSetRows bool
 	for q.Rows.Next() {
 		newObj := makeNew(sliceInnerType)
-
 		if isPopulatable {
-			err = asPopulatable(newObj).Populate(q.Rows)
+			err = AsPopulatable(newObj).Populate(q.Rows)
 		} else {
 			err = PopulateByName(newObj, q.Rows, meta, true)
 		}
@@ -179,6 +148,7 @@ func (q *Query) OutMany(collection interface{}) (err error) {
 		didSetRows = true
 	}
 
+	// this initializes the slice if we didn't add elements to it.
 	if !didSetRows {
 		collectionValue.Set(reflect.MakeSlice(sliceType, 0, 0))
 	}
@@ -206,6 +176,7 @@ func (q *Query) Each(consumer RowsConsumer) (err error) {
 }
 
 // First executes the consumer for the first result of a query.
+// It returns `ErrTooManyRows` if more than one result is returned.
 func (q *Query) First(consumer RowsConsumer) (err error) {
 	defer func() { err = q.finish(recover(), err) }()
 
@@ -227,6 +198,43 @@ func (q *Query) First(consumer RowsConsumer) (err error) {
 // --------------------------------------------------------------------------------
 // helpers
 // --------------------------------------------------------------------------------
+
+func (q *Query) populate(object interface{}, resetRowEmpty bool) (found bool, err error) {
+	defer func() { err = q.finish(recover(), err) }()
+	q.Rows, q.Err = q.query()
+	if q.Err != nil {
+		err = q.Err
+		return
+	}
+	defer func() { err = ex.Nest(err, Error(q.Rows.Close())) }()
+
+	sliceType := ReflectType(object)
+	if sliceType.Kind() != reflect.Struct {
+		err = Error(ErrDestinationNotStruct)
+		return
+	}
+
+	columnMeta := CachedColumnCollectionFromInstance(object)
+	if q.Rows.Next() {
+		found = true
+		if populatable, ok := object.(Populatable); ok {
+			err = populatable.Populate(q.Rows)
+		} else {
+			err = PopulateByName(object, q.Rows, columnMeta, resetRowEmpty)
+		}
+		if err != nil {
+			return
+		}
+	} else if _, ok := object.(Populatable); !ok {
+		PopulateEmpty(object, columnMeta)
+	}
+
+	if q.Rows.Next() {
+		err = Error(ErrTooManyRows)
+	}
+
+	return
+}
 
 func (q *Query) query() (rows *sql.Rows, err error) {
 	if q.Err != nil {

--- a/db/query.go
+++ b/db/query.go
@@ -91,9 +91,8 @@ func (q *Query) Scan(args ...interface{}) (found bool, err error) {
 }
 
 // Out writes the query result to a single object via. reflection mapping. If there is more than one result, the first
-// result is mapped to to object, and ErrTooManyRows is returned. Out() is different than ReadInto(), in that is DOES NOT change
-// struct fields on object that are empty in the result set. If a result field is null the value that was present in
-// object is maintained.
+// result is mapped to to object, and ErrTooManyRows is returned. Out() will apply column values for any colums
+// in the row result to the object, potentially zeroing existing values out.
 func (q *Query) Out(object interface{}) (found bool, err error) {
 	defer func() { err = q.finish(recover(), err) }()
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -1,10 +1,11 @@
 package db
 
 import (
-	"github.com/blend/go-sdk/uuid"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/blend/go-sdk/uuid"
 
 	"github.com/blend/go-sdk/assert"
 )
@@ -262,13 +263,13 @@ func TestQueryQueryPopulateByname(t *testing.T) {
 }
 
 type benchWithPointer struct {
-	ID        int       `db:"id,pk,auto"`
-	UUID      string    `db:"uuid,nullable,uk"`
-	Name      string    `db:"name"`
+	ID        int        `db:"id,pk,auto"`
+	UUID      string     `db:"uuid,nullable,uk"`
+	Name      string     `db:"name"`
 	Timestamp *time.Time `db:"timestamp_utc"`
-	Amount    float32   `db:"amount"`
-	Pending   bool      `db:"pending"`
-	Category  string    `db:"category"`
+	Amount    float32    `db:"amount"`
+	Pending   bool       `db:"pending"`
+	Category  string     `db:"category"`
 }
 
 func (t benchWithPointer) TableName() string {
@@ -286,23 +287,23 @@ func TestOutWithDirtyStructs(t *testing.T) {
 
 	uniq := uuid.V4().ToFullString()
 
-	i, err := defaultDB().Invoke(OptTx(tx)).Exec("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
+	i, err := defaultDB().Invoke(OptTx(tx)).ExecStats("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
 		uniq, "Foo", "Bar")
 	assert.Nil(err)
-	assert.Equal(1,i)
+	assert.Equal(1, i)
 
 	timeObj := time.Now()
 
 	dirty := benchWithPointer{
-		ID: 192,
-		UUID: uuid.V4().ToFullString(),
-		Name: "Widget",
+		ID:        192,
+		UUID:      uuid.V4().ToFullString(),
+		Name:      "Widget",
 		Timestamp: &timeObj,
-		Amount: 4.99,
-		Category: "Baz",
+		Amount:    4.99,
+		Category:  "Baz",
 	}
 
-	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).Out(&dirty)
+	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).ReadInto(&dirty)
 	assert.Nil(err)
 	assert.True(b)
 	assert.Nil(dirty.Timestamp)
@@ -320,23 +321,23 @@ func TestIntoWithDirtyStructs(t *testing.T) {
 
 	uniq := uuid.V4().ToFullString()
 
-	i, err := defaultDB().Invoke(OptTx(tx)).Exec("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
+	i, err := defaultDB().Invoke(OptTx(tx)).ExecStats("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
 		uniq, "Foo", "Bar")
 	assert.Nil(err)
-	assert.Equal(1,i)
+	assert.Equal(1, i)
 
 	timeObj := time.Now()
 
 	dirty := benchWithPointer{
-		ID: 192,
-		UUID: uuid.V4().ToFullString(),
-		Name: "Widget",
+		ID:        192,
+		UUID:      uuid.V4().ToFullString(),
+		Name:      "Widget",
 		Timestamp: &timeObj,
-		Amount: 4.99,
-		Category: "Baz",
+		Amount:    4.99,
+		Category:  "Baz",
 	}
 
-	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).Into(&dirty)
+	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).Out(&dirty)
 	assert.Nil(err)
 	assert.True(b)
 	assert.NotNil(dirty.Timestamp)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -287,10 +287,11 @@ func TestOutWithDirtyStructs(t *testing.T) {
 
 	uniq := uuid.V4().ToFullString()
 
-	i, err := defaultDB().Invoke(OptTx(tx)).ExecStats("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
+	i, err := defaultDB().Invoke(OptTx(tx)).Exec("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
 		uniq, "Foo", "Bar")
 	assert.Nil(err)
-	assert.Equal(1, i)
+	ra, _ := i.RowsAffected()
+	assert.Equal(1, ra)
 
 	timeObj := time.Now()
 
@@ -321,10 +322,11 @@ func TestIntoWithDirtyStructs(t *testing.T) {
 
 	uniq := uuid.V4().ToFullString()
 
-	i, err := defaultDB().Invoke(OptTx(tx)).ExecStats("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
+	i, err := defaultDB().Invoke(OptTx(tx)).Exec("INSERT INTO bench_object (uuid, name, category) VALUES ($1, $2, $3)",
 		uniq, "Foo", "Bar")
 	assert.Nil(err)
-	assert.Equal(1, i)
+	ra, _ := i.RowsAffected()
+	assert.Equal(1, ra)
 
 	timeObj := time.Now()
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -256,7 +256,7 @@ func TestQueryQueryPopulateByname(t *testing.T) {
 	var first benchObj
 	cols := Columns(first)
 	err = defaultDB().Invoke(OptTx(tx)).Query("select * from bench_object").First(func(r Rows) error {
-		return PopulateByName(&first, r, cols, true)
+		return PopulateByName(&first, r, cols)
 	})
 	assert.Nil(err)
 	assert.Equal(1, first.ID)
@@ -304,7 +304,7 @@ func TestOutWithDirtyStructs(t *testing.T) {
 		Category:  "Baz",
 	}
 
-	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).ReadInto(&dirty)
+	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).Out(&dirty)
 	assert.Nil(err)
 	assert.True(b)
 	assert.Nil(dirty.Timestamp)
@@ -342,6 +342,6 @@ func TestIntoWithDirtyStructs(t *testing.T) {
 	b, err := defaultDB().Invoke(OptTx(tx)).Query("SELECT * FROM bench_object WHERE uuid = $1", uniq).Out(&dirty)
 	assert.Nil(err)
 	assert.True(b)
-	assert.NotNil(dirty.Timestamp)
-	assert.True(dirty.Amount == 4.99)
+	assert.Nil(dirty.Timestamp)
+	assert.Zero(dirty.Amount)
 }

--- a/db/util.go
+++ b/db/util.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -46,6 +47,22 @@ func ParamTokens(startAt, count int) string {
 		}
 	}
 	return str
+}
+
+// IgnoreExecResult is a helper for use with .Exec() (sql.Result, error)
+// that ignores the result return.
+func IgnoreExecResult(_ sql.Result, err error) error {
+	return err
+}
+
+// ExecRowsAffected is a helper for use with .Exec() (sql.Result, error)
+// that returns the rows affected.
+func ExecRowsAffected(i sql.Result, err error) (int64, error) {
+	if err != nil {
+		return 0, err
+	}
+	ra, _ := i.RowsAffected()
+	return ra, nil
 }
 
 // --------------------------------------------------------------------------------

--- a/db/util.go
+++ b/db/util.go
@@ -53,12 +53,12 @@ func ParamTokens(startAt, count int) string {
 // --------------------------------------------------------------------------------
 
 // AsPopulatable casts an object as populatable.
-func asPopulatable(object interface{}) Populatable {
+func AsPopulatable(object interface{}) Populatable {
 	return object.(Populatable)
 }
 
-// isPopulatable returns if an object is populatable
-func isPopulatable(object interface{}) bool {
+// IsPopulatable returns if an object is populatable
+func IsPopulatable(object interface{}) bool {
 	_, isPopulatable := object.(Populatable)
 	return isPopulatable
 }

--- a/examples/db/bench/main.go
+++ b/examples/db/bench/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	for x := 0; x < 1<<12; x++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
-		err := conn.Invoke(db.OptContext(ctx)).Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", tableName), strconv.Itoa(x))
+		err := db.IgnoreExecResult(conn.Invoke(db.OptContext(ctx)).Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", tableName), strconv.Itoa(x)))
 		maybeFatal(err)
 		cancel()
 	}

--- a/examples/db/bench/main.go
+++ b/examples/db/bench/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	for x := 0; x < 1<<12; x++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
-		_, err := conn.Invoke(db.OptContext(ctx)).Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", tableName), strconv.Itoa(x))
+		err := conn.Invoke(db.OptContext(ctx)).Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", tableName), strconv.Itoa(x))
 		maybeFatal(err)
 		cancel()
 	}

--- a/examples/db/migration/timeouts/main.go
+++ b/examples/db/migration/timeouts/main.go
@@ -16,7 +16,7 @@ func main() {
 			migration.NewStep(
 				migration.Always(),
 				func(ctx context.Context, connection *db.Connection, tx *sql.Tx) error {
-					return connection.Invoke(db.OptTimeout(500 * time.Millisecond)).Exec("select pg_sleep(10);")
+					return db.IgnoreExecResult(connection.Invoke(db.OptTimeout(500 * time.Millisecond)).Exec("select pg_sleep(10);"))
 				},
 			),
 		),

--- a/examples/db/migration/timeouts/main.go
+++ b/examples/db/migration/timeouts/main.go
@@ -16,8 +16,7 @@ func main() {
 			migration.NewStep(
 				migration.Always(),
 				func(ctx context.Context, connection *db.Connection, tx *sql.Tx) error {
-					_, err := connection.Invoke(db.OptTimeout(500 * time.Millisecond)).Exec("select pg_sleep(10);")
-					return err
+					return connection.Invoke(db.OptTimeout(500 * time.Millisecond)).Exec("select pg_sleep(10);")
 				},
 			),
 		),

--- a/reverseproxy/proxy_test.go
+++ b/reverseproxy/proxy_test.go
@@ -48,6 +48,9 @@ func TestProxy(t *testing.T) {
 	assert.Nil(err)
 	defer res.Body.Close()
 
+	assert.Empty(res.Header.Get("x-forwarded-proto"))
+	assert.Empty(res.Header.Get("x-forwarded-port"))
+
 	fullBody, err := ioutil.ReadAll(res.Body)
 	assert.Nil(err)
 

--- a/stats/tracing/dbtrace/main_test.go
+++ b/stats/tracing/dbtrace/main_test.go
@@ -49,5 +49,5 @@ func createTable(tx *sql.Tx) error {
 	createSQL := `CREATE TABLE IF NOT EXISTS test_table (
 		id serial not null primary key
 	);`
-	return defaultDB().Invoke(db.OptTx(tx)).Exec(createSQL)
+	return db.IgnoreExecResult(defaultDB().Invoke(db.OptTx(tx)).Exec(createSQL))
 }

--- a/stats/tracing/dbtrace/main_test.go
+++ b/stats/tracing/dbtrace/main_test.go
@@ -2,9 +2,10 @@ package dbtrace
 
 import (
 	"database/sql"
-	"github.com/blend/go-sdk/logger"
 	"os"
 	"testing"
+
+	"github.com/blend/go-sdk/logger"
 
 	"github.com/blend/go-sdk/db"
 	_ "github.com/lib/pq"
@@ -48,6 +49,5 @@ func createTable(tx *sql.Tx) error {
 	createSQL := `CREATE TABLE IF NOT EXISTS test_table (
 		id serial not null primary key
 	);`
-	_, err := defaultDB().Invoke(db.OptTx(tx)).Exec(createSQL)
-	return err
+	return defaultDB().Invoke(db.OptTx(tx)).Exec(createSQL)
 }


### PR DESCRIPTION
## PR Summary

This PR unwinds some of the changes Mike made to make it a little less backwards compatibility disrupting, and more consistent within the package but also within the patterns of the repository.

A couple key things:
- Removes the distinction between `Out` and `ReadInto`, and removes `ReadInto`. `Out` will now fully apply any columns seen on a row, potentially setting fields to their zero value if the column contains a null. We do not wipe the object completely on `Out()`.
- `Exec` returns the underlying `sql.Result` from the stdlib function, and new helpers are added (`IgnoreExecResult` and `ExecRowsAffected`) have been added to help use this result.
- Adds `found` as a return on `Query::Scan()` to make it more consistent with `Out` and `ReadInto`.

 - **Type:** Improvements
 - **Intended Change Level:** major

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.