### PR TITLE
Adding support for attaching custom params to an airbrake notice from an error event

### DIFF
--- a/airbrake/listener.go
+++ b/airbrake/listener.go
@@ -21,6 +21,8 @@ func AddListeners(log logger.Listenable, cfg Config) {
 	listener := logger.NewErrorEventListener(func(_ context.Context, ee *logger.ErrorEvent) {
 		if req, ok := ee.State.(*http.Request); ok {
 			client.NotifyWithRequest(ee.Err, req)
+		} else if state, ok := ee.State.(Params); ok {
+			client.NotifyWithParams(ee.Err, state)
 		} else {
 			client.Notify(ee.Err)
 		}

--- a/airbrake/listener.go
+++ b/airbrake/listener.go
@@ -21,8 +21,11 @@ func AddListeners(log logger.Listenable, cfg Config) {
 	listener := logger.NewErrorEventListener(func(_ context.Context, ee *logger.ErrorEvent) {
 		if req, ok := ee.State.(*http.Request); ok {
 			client.NotifyWithRequest(ee.Err, req)
-		} else if state, ok := ee.State.(Params); ok {
-			client.NotifyWithParams(ee.Err, state)
+		} else if state, ok := ee.State.(interface{}); ok {
+			errStateMap := map[string]interface{}{
+				"ErrorState": state,
+			}
+			client.NotifyWithParams(ee.Err, errStateMap)
 		} else {
 			client.Notify(ee.Err)
 		}

--- a/airbrake/notice.go
+++ b/airbrake/notice.go
@@ -9,9 +9,6 @@ import (
 	"github.com/blend/go-sdk/webutil"
 )
 
-// Params is a custom type alias
-type Params map[string]interface{}
-
 // NewNotice returns a new gobrake notice.
 func NewNotice(err interface{}, req *http.Request) *gobrake.Notice {
 	var notice *gobrake.Notice
@@ -36,7 +33,7 @@ func NewNotice(err interface{}, req *http.Request) *gobrake.Notice {
 			Context: make(map[string]interface{}),
 			Env:     make(map[string]interface{}),
 			Session: make(map[string]interface{}),
-			Params:  make(Params),
+			Params:  make(map[string]interface{}),
 		}
 	} else {
 		notice = &gobrake.Notice{

--- a/airbrake/notice.go
+++ b/airbrake/notice.go
@@ -9,6 +9,9 @@ import (
 	"github.com/blend/go-sdk/webutil"
 )
 
+// Params is a custom type alias
+type Params map[string]interface{}
+
 // NewNotice returns a new gobrake notice.
 func NewNotice(err interface{}, req *http.Request) *gobrake.Notice {
 	var notice *gobrake.Notice
@@ -33,7 +36,7 @@ func NewNotice(err interface{}, req *http.Request) *gobrake.Notice {
 			Context: make(map[string]interface{}),
 			Env:     make(map[string]interface{}),
 			Session: make(map[string]interface{}),
-			Params:  make(map[string]interface{}),
+			Params:  make(Params),
 		}
 	} else {
 		notice = &gobrake.Notice{
@@ -61,6 +64,13 @@ func NewNotice(err interface{}, req *http.Request) *gobrake.Notice {
 		}
 		notice.Context["userAddr"] = webutil.GetRemoteAddr(req)
 	}
+	return notice
+}
+
+// NewNoticeWithParams adds a map of params to the new default gobrake notice.
+func NewNoticeWithParams(err interface{}, params map[string]interface{}) *gobrake.Notice {
+	notice := NewNotice(err, nil)
+	notice.Params = params
 	return notice
 }
 

--- a/airbrake/notifier.go
+++ b/airbrake/notifier.go
@@ -77,7 +77,7 @@ func (n *Notifier) NotifyWithRequest(err interface{}, req *http.Request) error {
 }
 
 // NotifyWithParams sends an error with custom parameters attached.
-func (n *Notifier) NotifyWithParams(err interface{}, params Params) error {
+func (n *Notifier) NotifyWithParams(err interface{}, params map[string]interface{}) error {
 	_, sendErr := n.Client.SendNotice(NewNoticeWithParams(err, params))
 	return ex.New(sendErr)
 }

--- a/airbrake/notifier.go
+++ b/airbrake/notifier.go
@@ -76,6 +76,12 @@ func (n *Notifier) NotifyWithRequest(err interface{}, req *http.Request) error {
 	return ex.New(sendErr)
 }
 
+// NotifyWithParams sends an error with custom parameters attached.
+func (n *Notifier) NotifyWithParams(err interface{}, params Params) error {
+	_, sendErr := n.Client.SendNotice(NewNoticeWithParams(err, params))
+	return ex.New(sendErr)
+}
+
 func getDefaultContext() map[string]interface{} {
 	defaultContextOnce.Do(func() {
 		defaultContext = map[string]interface{}{

--- a/logger/context.go
+++ b/logger/context.go
@@ -142,12 +142,16 @@ func (sc Context) Error(err error) error {
 	return err
 }
 
-// ErrorWithReq logs an error to std err with a request.
-func (sc Context) ErrorWithReq(err error, req *http.Request) error {
-	ee := NewErrorEvent(Error, err)
-	ee.State = req
+// ErrorWithState logs an error to std with a generic state.
+func (sc Context) ErrorWithState(err error, state interface{}) error {
+	ee := NewErrorEvent(Error, err, OptErrorEventState(state))
 	sc.Trigger(context.Background(), ee)
 	return err
+}
+
+// ErrorWithReq logs an error to std err with a request.
+func (sc Context) ErrorWithReq(err error, req *http.Request) error {
+	return sc.ErrorWithState(err, req)
 }
 
 // Fatal logs an error as fatal.


### PR DESCRIPTION
## PR Summary

*Replace this text with a description of what this PR is accomplishing*

 - **Type:** Features
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.