### PR TITLE
Don't set the forwarded headers on the response

### DIFF
--- a/reverseproxy/upstream.go
+++ b/reverseproxy/upstream.go
@@ -71,12 +71,5 @@ func (u *Upstream) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}()
 	}
 
-	// Add extra forwarded headers.
-	// these are required for a majority of services to function correctly behind
-	// a reverse proxy.
-	// We do an add here in case they're already specified.
-	w.Header().Add("X-Forwarded-Port", req.URL.Port())
-	w.Header().Add("X-Forwarded-Proto", req.URL.Scheme)
-
 	u.ReverseProxy.ServeHTTP(w, req)
 }

--- a/reverseproxy/upstream_test.go
+++ b/reverseproxy/upstream_test.go
@@ -1,6 +1,9 @@
 package reverseproxy
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
@@ -11,4 +14,36 @@ func TestUpstreamWithoutHopHeaders(t *testing.T) {
 
 	u := NewUpstream(MustParseURL("http://localhost:5000"))
 	assert.NotNil(u.ReverseProxy)
+}
+
+func TestUpstreamServeHTTP(t *testing.T) {
+	assert := assert.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK!\n")
+	}))
+	defer srv.Close()
+
+	u := NewUpstream(MustParseURL(srv.URL))
+	assert.NotNil(u.ReverseProxy)
+	u.Log = nil
+
+	proxy := NewProxy()
+	proxy.Upstreams = append(proxy.Upstreams, u)
+
+	server := &http.Server{}
+	server.Handler = proxy
+	server.Addr = fmt.Sprintf("localhost:%s", "5000")
+	go server.ListenAndServe()
+	defer server.Close()
+
+	req, err := http.NewRequest("GET", "http://localhost:5000", nil)
+	assert.Nil(err)
+
+	res, err := http.DefaultClient.Do(req)
+	assert.Nil(err)
+
+	assert.Empty(res.Header.Get("X-Forwarded-For"))
+	assert.Empty(res.Header.Get("X-Forwarded-Port"))
 }

--- a/reverseproxy/upstream_test.go
+++ b/reverseproxy/upstream_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
+	"github.com/blend/go-sdk/logger"
 )
 
 func TestUpstreamWithoutHopHeaders(t *testing.T) {
@@ -27,7 +28,7 @@ func TestUpstreamServeHTTP(t *testing.T) {
 
 	u := NewUpstream(MustParseURL(srv.URL))
 	assert.NotNil(u.ReverseProxy)
-	u.Log = nil
+	u.Log = logger.None()
 
 	proxy := NewProxy()
 	proxy.Upstreams = append(proxy.Upstreams, u)


### PR DESCRIPTION
## PR Summary

Remove x-forwarded-for and x-forwarded-port from the reverseproxy response

 - **Type:** Bugfix
 - **Issue Link:** 
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.