### PR TITLE
Listen for TLS connections before accepting proxy protocol connections.

### DIFF
--- a/proxyprotocol/create_listener.go
+++ b/proxyprotocol/create_listener.go
@@ -26,11 +26,12 @@ func CreateListener(addr string, opts ...CreateListenerOption) (net.Listener, er
 
 	var output net.Listener = webutil.TCPKeepAliveListener{TCPListener: ln.(*net.TCPListener)}
 
-	if options.TLSConfig != nil {
-		output = tls.NewListener(output, options.TLSConfig)
-	}
 	if options.UseProxyProtocol {
 		output = &Listener{Listener: output}
 	}
+	if options.TLSConfig != nil {
+		output = tls.NewListener(output, options.TLSConfig)
+	}
+
 	return output, nil
 }

--- a/proxyprotocol/create_listener_test.go
+++ b/proxyprotocol/create_listener_test.go
@@ -1,6 +1,8 @@
 package proxyprotocol
 
 import (
+	"crypto/tls"
+	"reflect"
 	"testing"
 	"time"
 
@@ -30,4 +32,23 @@ func TestCreateListener(t *testing.T) {
 	tcpListener, ok := typed.Listener.(webutil.TCPKeepAliveListener)
 	assert.True(ok)
 	assert.NotNil(tcpListener)
+}
+
+func TestCreateTLSListener(t *testing.T) {
+	assert := assert.New(t)
+
+	tlsConfig := &tls.Config{}
+	listener, err := CreateListener("127.0.0.1:",
+		OptKeepAlive(true),
+		OptUseProxyProtocol(true),
+		OptKeepAlivePeriod(30*time.Second),
+		OptTLSConfig(tlsConfig),
+	)
+	defer listener.Close()
+
+	assert.Nil(err)
+	assert.NotNil(listener)
+
+	// hacky use of reflection to verify that the created listener can handle tls connections
+	assert.Equal("*tls.listener", reflect.TypeOf(listener).String())
 }

--- a/proxyprotocol/create_listener_test.go
+++ b/proxyprotocol/create_listener_test.go
@@ -2,7 +2,7 @@ package proxyprotocol
 
 import (
 	"crypto/tls"
-	"reflect"
+	"net"
 	"testing"
 	"time"
 
@@ -49,6 +49,15 @@ func TestCreateTLSListener(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(listener)
 
-	// hacky use of reflection to verify that the created listener can handle tls connections
-	assert.Equal("*tls.listener", reflect.TypeOf(listener).String())
+	go func() {
+		_, err := net.Dial("tcp", listener.Addr().String())
+		assert.Nil(err)
+	}()
+
+	conn, err := listener.Accept()
+	assert.Nil(err)
+
+	typed, ok := conn.(*tls.Conn)
+	assert.True(ok)
+	assert.NotNil(typed)
 }


### PR DESCRIPTION
## PR Summary

When setting up a web service to use a listener created by `proxyprotocol.CreateListener` (a listener configured to handle proxyprotocol and TLS), I was getting TLS handshake errors when attempting to talk to the service behind an AWS classic ELB. Switching the order of these listeners fixes this TLS handshake issue.

 - **Type:** Bugfixes
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.