### PR TITLE
Adds `breaker` package.

### DIFF
--- a/breaker/breaker.go
+++ b/breaker/breaker.go
@@ -1,0 +1,241 @@
+package breaker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/blend/go-sdk/ex"
+)
+
+type (
+	// Action is a piece of code to run.
+	Action func(context.Context) (interface{}, error)
+	// OnStateChangeHandler is called when the state changes.
+	OnStateChangeHandler func(ctx context.Context, from, to State, generation int64)
+	// ShouldCloseProvider returns if the breaker should close.
+	ShouldCloseProvider func(ctx context.Context, counts Counts) bool
+	// NowProvider returns the current time.
+	NowProvider func() time.Time
+)
+
+// MustNew returns a new breaker and panics if there is a construction error.
+func MustNew(options ...Option) *Breaker {
+	b, err := New(options...)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// New creates a new breaker with the given options.
+func New(options ...Option) (*Breaker, error) {
+	b := Breaker{
+		ClosedExpiryInterval: DefaultClosedExpiryInterval,
+		OpenExpiryInterval:   DefaultOpenExpiryInterval,
+		HalfOpenMaxActions:   DefaultHalfOpenMaxActions,
+	}
+	for _, opt := range options {
+		if err := opt(&b); err != nil {
+			return nil, err
+		}
+	}
+	return &b, nil
+}
+
+// Breaker is a state machine to prevent performing actions that are likely to fail.
+type Breaker struct {
+	sync.Mutex
+
+	// OpenAction is an optional action to be called when the breaker is open (i.e. preventing calls
+	// to the main action handler.)
+	OpenAction Action
+
+	// OnStateChange is an optional handler called when the breaker transitions state.
+	OnStateChange OnStateChangeHandler
+	// ShouldCloseProvider is called optionally to determine if we should close the breaker.
+	ShouldCloseProvider ShouldCloseProvider
+	// NowProvider lets you optionally inject the current time for testing.
+	NowProvider
+
+	// HalfOpenMaxActions is the maximum number of requests
+	// we can make when the state is HalfOpen.
+	HalfOpenMaxActions int64
+	// ClosedExpiryInterval is the cyclic period of the closed state for the CircuitBreaker to clear the internal Counts.
+	// If Interval is 0, the CircuitBreaker doesn't clear internal Counts during the closed state.
+	ClosedExpiryInterval time.Duration
+	// OpenExpiryInterval is the period of the open state,
+	// after which the state of the CircuitBreaker becomes half-open.
+	// If Timeout is 0, the timeout value of the CircuitBreaker is set to 60 seconds.
+	OpenExpiryInterval time.Duration
+	// State is the current breaker state (Open, HalfOpen, Closed).
+	// Counts are stats for the breaker.
+	Counts Counts
+
+	// state is the current Breaker state (Closed, HalfOpen, Open etc.)
+	state State
+	// generation is the current state generation.
+	generation int64
+	// stateExpiresAt is the time when the current state will expire.
+	// It is set when we change state according to the interval
+	// and the current time.
+	stateExpiresAt time.Time
+}
+
+// Do runs the given action if the Breaker accepts it.
+// Do returns an error instantly if the Breaker rejects the request.
+// Otherwise, Do returns the result of the request.
+// If a panic occurs in the request, the Breaker handles it as an error.
+func (b *Breaker) Do(ctx context.Context, action Action) (interface{}, error) {
+	generation, err := b.beforeAction(ctx)
+	if err != nil {
+		if b.OpenAction != nil {
+			return b.OpenAction(ctx)
+		}
+		return nil, err
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			b.afterAction(ctx, generation, false)
+		}
+	}()
+
+	res, err := action(ctx)
+	b.afterAction(ctx, generation, err == nil)
+	return res, err
+}
+
+// State returns the current state of the CircuitBreaker.
+func (b *Breaker) State(ctx context.Context) State {
+	b.Lock()
+	defer b.Unlock()
+
+	now := time.Now()
+	state, _ := b.getState(ctx, now)
+	return state
+}
+
+func (b *Breaker) beforeAction(ctx context.Context) (int64, error) {
+	b.Lock()
+	defer b.Unlock()
+
+	now := b.now()
+	state, generation := b.getState(ctx, now)
+
+	if state == StateOpen {
+		return generation, ex.New(ErrOpenState)
+	} else if state == StateHalfOpen && b.Counts.Requests >= b.HalfOpenMaxActions {
+		return generation, ex.New(ErrTooManyRequests)
+	}
+
+	atomic.AddInt64(&b.Counts.Requests, 1)
+	return generation, nil
+}
+
+func (b *Breaker) afterAction(ctx context.Context, generation int64, success bool) {
+	b.Lock()
+	defer b.Unlock()
+
+	now := b.now()
+	state, generation := b.getState(ctx, now)
+	if generation != generation {
+		return
+	}
+
+	if success {
+		b.success(ctx, state, now)
+		return
+	}
+	b.failure(ctx, state, now)
+}
+
+func (b *Breaker) success(ctx context.Context, state State, now time.Time) {
+	switch state {
+	case StateClosed:
+		atomic.AddInt64(&b.Counts.TotalSuccesses, 1)
+		atomic.AddInt64(&b.Counts.ConsecutiveSuccesses, 1)
+		atomic.StoreInt64(&b.Counts.ConsecutiveFailures, 0)
+	case StateHalfOpen:
+		atomic.AddInt64(&b.Counts.TotalSuccesses, 1)
+		atomic.AddInt64(&b.Counts.ConsecutiveSuccesses, 1)
+		atomic.StoreInt64(&b.Counts.ConsecutiveFailures, 0)
+		if b.Counts.ConsecutiveSuccesses >= b.HalfOpenMaxActions {
+			b.setState(ctx, StateClosed, now)
+		}
+	}
+}
+
+func (b *Breaker) failure(ctx context.Context, state State, now time.Time) {
+	switch state {
+	case StateClosed:
+		atomic.AddInt64(&b.Counts.TotalFailures, 1)
+		atomic.AddInt64(&b.Counts.ConsecutiveFailures, 1)
+		atomic.StoreInt64(&b.Counts.ConsecutiveSuccesses, 0)
+		if b.shouldClose(ctx) {
+			b.setState(ctx, StateOpen, now)
+		}
+	case StateHalfOpen:
+		b.setState(ctx, StateOpen, now)
+	}
+}
+
+func (b *Breaker) getState(ctx context.Context, t time.Time) (state State, generation int64) {
+	switch b.state {
+	case StateClosed:
+		if !b.stateExpiresAt.IsZero() && b.stateExpiresAt.Before(t) {
+			b.incrementGeneration(t)
+		}
+	case StateOpen:
+		if b.stateExpiresAt.Before(t) {
+			b.setState(ctx, StateHalfOpen, t)
+		}
+	}
+	return b.state, b.generation
+}
+
+func (b *Breaker) setState(ctx context.Context, state State, now time.Time) {
+	if b.state == state {
+		return
+	}
+
+	previousState := b.state
+	b.state = state
+	b.incrementGeneration(now)
+	if b.OnStateChange != nil {
+		b.OnStateChange(ctx, previousState, b.state, b.generation)
+	}
+}
+
+func (b *Breaker) incrementGeneration(now time.Time) {
+	atomic.AddInt64(&b.generation, 1)
+	b.Counts = Counts{}
+
+	var zero time.Time
+	switch b.state {
+	case StateClosed:
+		if b.ClosedExpiryInterval == 0 {
+			b.stateExpiresAt = zero
+		} else {
+			b.stateExpiresAt = now.Add(b.ClosedExpiryInterval)
+		}
+	case StateOpen:
+		b.stateExpiresAt = now.Add(b.OpenExpiryInterval)
+	default: // StateHalfOpen
+		b.stateExpiresAt = zero
+	}
+}
+
+func (b *Breaker) shouldClose(ctx context.Context) bool {
+	if b.ShouldCloseProvider != nil {
+		return b.ShouldCloseProvider(ctx, b.Counts)
+	}
+	return b.Counts.ConsecutiveFailures > DefaultConsecutiveFailures
+}
+
+func (b *Breaker) now() time.Time {
+	if b.NowProvider != nil {
+		return b.NowProvider()
+	}
+	return time.Now()
+}

--- a/breaker/breaker_test.go
+++ b/breaker/breaker_test.go
@@ -67,22 +67,22 @@ func TestBreaker(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		assert.Nil(fail(ctx, b))
 	}
-	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(StateClosed, b.EvaluateState(ctx))
 	assert.Equal(Counts{5, 0, 5, 0, 5}, b.Counts)
 
 	assert.Nil(succeed(ctx, b))
-	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(StateClosed, b.EvaluateState(ctx))
 	assert.Equal(Counts{6, 1, 5, 1, 0}, b.Counts)
 
 	assert.Nil(fail(ctx, b))
-	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(StateClosed, b.EvaluateState(ctx))
 	assert.Equal(Counts{7, 1, 6, 0, 1}, b.Counts)
 
 	// StateClosed to StateOpen
 	for i := 0; i < 5; i++ {
 		assert.Nil(fail(ctx, b)) // 6 consecutive failures
 	}
-	assert.Equal(StateOpen, b.State(ctx))
+	assert.Equal(StateOpen, b.EvaluateState(ctx))
 	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
 	assert.False(b.stateExpiresAt.IsZero())
 
@@ -91,27 +91,27 @@ func TestBreaker(t *testing.T) {
 	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
 
 	pseudoSleep(b, time.Duration(59)*time.Second)
-	assert.Equal(StateOpen, b.State(ctx))
+	assert.Equal(StateOpen, b.EvaluateState(ctx))
 
 	// StateOpen to StateHalfOpen
 	pseudoSleep(b, time.Duration(1)*time.Second) // over Timeout
-	assert.Equal(StateHalfOpen, b.State(ctx))
+	assert.Equal(StateHalfOpen, b.EvaluateState(ctx))
 	assert.True(b.stateExpiresAt.IsZero())
 
 	// StateHalfOpen to StateOpen
 	assert.Nil(fail(ctx, b))
-	assert.Equal(StateOpen, b.State(ctx))
+	assert.Equal(StateOpen, b.EvaluateState(ctx))
 	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
 	assert.False(b.stateExpiresAt.IsZero())
 
 	// StateOpen to StateHalfOpen
 	pseudoSleep(b, time.Duration(60)*time.Second)
-	assert.Equal(StateHalfOpen, b.State(ctx))
+	assert.Equal(StateHalfOpen, b.EvaluateState(ctx))
 	assert.True(b.stateExpiresAt.IsZero())
 
 	// StateHalfOpen to StateClosed
 	assert.Nil(succeed(ctx, b))
-	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(StateClosed, b.EvaluateState(ctx))
 	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
 	assert.True(b.stateExpiresAt.IsZero())
 }

--- a/breaker/breaker_test.go
+++ b/breaker/breaker_test.go
@@ -1,0 +1,178 @@
+package breaker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/blend/go-sdk/assert"
+	"github.com/blend/go-sdk/ex"
+)
+
+func TestNew(t *testing.T) {
+	assert := assert.New(t)
+
+	b, err := New()
+	assert.Nil(err)
+	assert.Equal(DefaultHalfOpenMaxActions, b.HalfOpenMaxActions)
+	assert.Equal(DefaultOpenExpiryInterval, b.OpenExpiryInterval)
+	assert.Equal(DefaultClosedExpiryInterval, b.ClosedExpiryInterval)
+}
+
+func TestNewOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	b, err := New(
+		OptHalfOpenMaxActions(5),
+		OptOpenExpiryInterval(10*time.Second),
+		OptClosedExpiryInterval(20*time.Second),
+	)
+	assert.Nil(err)
+	assert.Equal(5, b.HalfOpenMaxActions)
+	assert.Equal(10*time.Second, b.OpenExpiryInterval)
+	assert.Equal(20*time.Second, b.ClosedExpiryInterval)
+}
+
+func createTestBreaker() *Breaker {
+	return MustNew(OptClosedExpiryInterval(0))
+}
+
+func succeed(ctx context.Context, b *Breaker) error {
+	_, err := b.Do(ctx, func(_ context.Context) (interface{}, error) { return nil, nil })
+	return err
+}
+
+func pseudoSleep(b *Breaker, period time.Duration) {
+	if !b.stateExpiresAt.IsZero() {
+		b.stateExpiresAt = b.stateExpiresAt.Add(-period)
+	}
+}
+
+func fail(ctx context.Context, b *Breaker) error {
+	msg := "fail"
+	_, err := b.Do(ctx, func(_ context.Context) (interface{}, error) { return nil, fmt.Errorf(msg) })
+	if err.Error() == msg {
+		return nil
+	}
+	return err
+}
+
+func TestBreaker(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	b := createTestBreaker()
+
+	for i := 0; i < 5; i++ {
+		assert.Nil(fail(ctx, b))
+	}
+	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(Counts{5, 0, 5, 0, 5}, b.Counts)
+
+	assert.Nil(succeed(ctx, b))
+	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(Counts{6, 1, 5, 1, 0}, b.Counts)
+
+	assert.Nil(fail(ctx, b))
+	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(Counts{7, 1, 6, 0, 1}, b.Counts)
+
+	// StateClosed to StateOpen
+	for i := 0; i < 5; i++ {
+		assert.Nil(fail(ctx, b)) // 6 consecutive failures
+	}
+	assert.Equal(StateOpen, b.State(ctx))
+	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
+	assert.False(b.stateExpiresAt.IsZero())
+
+	assert.NotNil(succeed(ctx, b))
+	assert.NotNil(fail(ctx, b))
+	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
+
+	pseudoSleep(b, time.Duration(59)*time.Second)
+	assert.Equal(StateOpen, b.State(ctx))
+
+	// StateOpen to StateHalfOpen
+	pseudoSleep(b, time.Duration(1)*time.Second) // over Timeout
+	assert.Equal(StateHalfOpen, b.State(ctx))
+	assert.True(b.stateExpiresAt.IsZero())
+
+	// StateHalfOpen to StateOpen
+	assert.Nil(fail(ctx, b))
+	assert.Equal(StateOpen, b.State(ctx))
+	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
+	assert.False(b.stateExpiresAt.IsZero())
+
+	// StateOpen to StateHalfOpen
+	pseudoSleep(b, time.Duration(60)*time.Second)
+	assert.Equal(StateHalfOpen, b.State(ctx))
+	assert.True(b.stateExpiresAt.IsZero())
+
+	// StateHalfOpen to StateClosed
+	assert.Nil(succeed(ctx, b))
+	assert.Equal(StateClosed, b.State(ctx))
+	assert.Equal(Counts{0, 0, 0, 0, 0}, b.Counts)
+	assert.True(b.stateExpiresAt.IsZero())
+}
+
+func TestBreakerErrStateOpen(t *testing.T) {
+	assert := assert.New(t)
+
+	var didCall bool
+	b, err := New()
+	assert.Nil(err)
+
+	b.state = StateOpen
+	b.stateExpiresAt = time.Now().Add(time.Hour)
+
+	_, err = b.Do(context.Background(), func(_ context.Context) (interface{}, error) {
+		didCall = true
+		return nil, nil
+	})
+	assert.True(ex.Is(err, ErrOpenState), fmt.Sprintf("%v", err))
+	assert.False(didCall)
+}
+
+func TestBreakerErrTooManyRequests(t *testing.T) {
+	assert := assert.New(t)
+
+	var didCall bool
+	b, err := New()
+	assert.Nil(err)
+
+	b.state = StateHalfOpen
+	b.Counts.Requests = 10
+	b.HalfOpenMaxActions = 5
+
+	_, err = b.Do(context.Background(), func(_ context.Context) (interface{}, error) {
+		didCall = true
+		return nil, nil
+	})
+	assert.True(ex.Is(err, ErrTooManyRequests))
+	assert.False(didCall)
+}
+
+func TestBreakerCallsOnOpenHandler(t *testing.T) {
+	assert := assert.New(t)
+
+	var didCall, didCallOpen bool
+	b, err := New(OptOpenAction(func(_ context.Context) (interface{}, error) {
+		didCallOpen = true
+		return "on open", nil
+	}))
+	assert.Nil(err)
+
+	b.state = StateOpen
+	b.stateExpiresAt = time.Now().Add(time.Hour)
+
+	res, err := b.Do(context.Background(), func(_ context.Context) (interface{}, error) {
+		didCall = true
+		return nil, nil
+	})
+
+	assert.Nil(err)
+	assert.False(didCall)
+	assert.True(didCallOpen)
+	assert.Equal("on open", res)
+}

--- a/breaker/config.go
+++ b/breaker/config.go
@@ -1,0 +1,10 @@
+package breaker
+
+import "time"
+
+// Config is the breaker config.
+type Config struct {
+	HalfOpenMaxActions   int64         `json:"halfOpenMaxActions" yaml:"halfOpenMaxActions"`
+	ClosedExpiryInterval time.Duration `json:"closedExpiryInterval" yaml:"closedExpiryInterval"`
+	OpenExpiryInterval   time.Duration `json:"openExpiryInterval" yaml:"openExpiryInterval"`
+}

--- a/breaker/constants.go
+++ b/breaker/constants.go
@@ -1,0 +1,11 @@
+package breaker
+
+import "time"
+
+// Constants
+const (
+	DefaultClosedExpiryInterval = 5 * time.Second
+	DefaultOpenExpiryInterval   = 60 * time.Second
+	DefaultHalfOpenMaxActions   = 1
+	DefaultConsecutiveFailures  = 5
+)

--- a/breaker/counts.go
+++ b/breaker/counts.go
@@ -1,0 +1,13 @@
+package breaker
+
+// Counts holds the numbers of requests and their successes/failures.
+// CircuitBreaker clears the internal Counts either
+// on the change of the state or at the closed-state intervals.
+// Counts ignores the results of the requests sent before clearing.
+type Counts struct {
+	Requests             int64 `json:"requests"`
+	TotalSuccesses       int64 `json:"totalSuccesses"`
+	TotalFailures        int64 `json:"totalFailures"`
+	ConsecutiveSuccesses int64 `json:"consecutiveSuccesses"`
+	ConsecutiveFailures  int64 `json:"consecutiveFailures"`
+}

--- a/breaker/errors.go
+++ b/breaker/errors.go
@@ -1,0 +1,20 @@
+package breaker
+
+import "github.com/blend/go-sdk/ex"
+
+var (
+	// ErrTooManyRequests is returned when the CB state is half open and the requests count is over the cb maxRequests
+	ErrTooManyRequests ex.Class = "too many requests"
+	// ErrOpenState is returned when the CB state is open
+	ErrOpenState ex.Class = "circuit breaker is open"
+)
+
+// ErrIsOpen returns if the error is an ErrOpenState.
+func ErrIsOpen(err error) bool {
+	return ex.Is(err, ErrOpenState)
+}
+
+// ErrIsTooManyRequests returns if the error is an ErrTooManyRequests.
+func ErrIsTooManyRequests(err error) bool {
+	return ex.Is(err, ErrTooManyRequests)
+}

--- a/breaker/errors_test.go
+++ b/breaker/errors_test.go
@@ -1,0 +1,24 @@
+package breaker
+
+import (
+	"testing"
+
+	"github.com/blend/go-sdk/assert"
+	"github.com/blend/go-sdk/ex"
+)
+
+func TestErrIsOpen(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(ErrIsOpen(ex.New(ErrOpenState)))
+	assert.False(ErrIsOpen(nil))
+	assert.False(ErrIsOpen(ex.New(ErrTooManyRequests)))
+}
+
+func TestErrIsTooManyRequests(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(ErrIsTooManyRequests(ex.New(ErrTooManyRequests)))
+	assert.False(ErrIsTooManyRequests(nil))
+	assert.False(ErrIsTooManyRequests(ex.New(ErrOpenState)))
+}

--- a/breaker/option.go
+++ b/breaker/option.go
@@ -57,10 +57,10 @@ func OptOnStateChange(handler OnStateChangeHandler) Option {
 	}
 }
 
-// OptShouldCloseProvider sets the ShouldCloseProvider provider on the breaker.
-func OptShouldCloseProvider(provider ShouldCloseProvider) Option {
+// OptShouldOpenProvider sets the ShouldCloseProvider provider on the breaker.
+func OptShouldOpenProvider(provider ShouldOpenProvider) Option {
 	return func(b *Breaker) error {
-		b.ShouldCloseProvider = provider
+		b.ShouldOpenProvider = provider
 		return nil
 	}
 }

--- a/breaker/option.go
+++ b/breaker/option.go
@@ -1,0 +1,74 @@
+package breaker
+
+import (
+	"time"
+)
+
+// Option is a mutator for a breaker.
+type Option func(*Breaker) error
+
+// OptHalfOpenMaxActions sets the HalfOpenMaxActions.
+func OptHalfOpenMaxActions(maxActions int64) Option {
+	return func(b *Breaker) error {
+		b.HalfOpenMaxActions = maxActions
+		return nil
+	}
+}
+
+// OptClosedExpiryInterval sets the ClosedExpiryInterval.
+func OptClosedExpiryInterval(interval time.Duration) Option {
+	return func(b *Breaker) error {
+		b.ClosedExpiryInterval = interval
+		return nil
+	}
+}
+
+// OptOpenExpiryInterval sets the OpenExpiryInterval.
+func OptOpenExpiryInterval(interval time.Duration) Option {
+	return func(b *Breaker) error {
+		b.OpenExpiryInterval = interval
+		return nil
+	}
+}
+
+// OptConfig sets the breaker based on a config.
+func OptConfig(cfg Config) Option {
+	return func(b *Breaker) error {
+		b.HalfOpenMaxActions = cfg.HalfOpenMaxActions
+		b.ClosedExpiryInterval = cfg.ClosedExpiryInterval
+		b.OpenExpiryInterval = cfg.OpenExpiryInterval
+		return nil
+	}
+}
+
+// OptOpenAction sets the open action on the breaker.
+func OptOpenAction(action Action) Option {
+	return func(b *Breaker) error {
+		b.OpenAction = action
+		return nil
+	}
+}
+
+// OptOnStateChange sets the OnStateChange handler on the breaker.
+func OptOnStateChange(handler OnStateChangeHandler) Option {
+	return func(b *Breaker) error {
+		b.OnStateChange = handler
+		return nil
+	}
+}
+
+// OptShouldCloseProvider sets the ShouldCloseProvider provider on the breaker.
+func OptShouldCloseProvider(provider ShouldCloseProvider) Option {
+	return func(b *Breaker) error {
+		b.ShouldCloseProvider = provider
+		return nil
+	}
+}
+
+// OptNowProvider sets the now provider on the breaker.
+func OptNowProvider(provider NowProvider) Option {
+	return func(b *Breaker) error {
+		b.NowProvider = provider
+		return nil
+	}
+}

--- a/breaker/option_test.go
+++ b/breaker/option_test.go
@@ -70,13 +70,13 @@ func TestOptOnStateChange(t *testing.T) {
 	assert.NotNil(b.OnStateChange)
 }
 
-func TestOptShouldCloseProvider(t *testing.T) {
+func TestOptShouldOpenProvider(t *testing.T) {
 	assert := assert.New(t)
 
 	b := new(Breaker)
-	assert.Nil(b.ShouldCloseProvider)
-	OptShouldCloseProvider(func(ctx context.Context, counts Counts) bool { return false })(b)
-	assert.NotNil(b.ShouldCloseProvider)
+	assert.Nil(b.ShouldOpenProvider)
+	OptShouldOpenProvider(func(ctx context.Context, counts Counts) bool { return false })(b)
+	assert.NotNil(b.ShouldOpenProvider)
 }
 
 func TestOptNowProvider(t *testing.T) {

--- a/breaker/option_test.go
+++ b/breaker/option_test.go
@@ -1,0 +1,89 @@
+package breaker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestOptHalfOpenMaxActions(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Zero(b.HalfOpenMaxActions)
+	OptHalfOpenMaxActions(5)(b)
+	assert.Equal(5, b.HalfOpenMaxActions)
+}
+
+func TestOptClosedExpiryInterval(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Zero(b.ClosedExpiryInterval)
+	OptClosedExpiryInterval(5 * time.Second)(b)
+	assert.Equal(5*time.Second, b.ClosedExpiryInterval)
+}
+
+func TestOptOpenExpiryInterval(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Zero(b.OpenExpiryInterval)
+	OptOpenExpiryInterval(5 * time.Second)(b)
+	assert.Equal(5*time.Second, b.OpenExpiryInterval)
+}
+
+func TestOptConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Zero(b.HalfOpenMaxActions)
+	assert.Zero(b.ClosedExpiryInterval)
+	assert.Zero(b.OpenExpiryInterval)
+	OptConfig(Config{
+		HalfOpenMaxActions:   1,
+		ClosedExpiryInterval: 2 * time.Second,
+		OpenExpiryInterval:   3 * time.Second,
+	})(b)
+	assert.Equal(1, b.HalfOpenMaxActions)
+	assert.Equal(2*time.Second, b.ClosedExpiryInterval)
+	assert.Equal(3*time.Second, b.OpenExpiryInterval)
+}
+
+func TestOptOpenAction(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Nil(b.OpenAction)
+	OptOpenAction(func(_ context.Context) (interface{}, error) { return nil, nil })(b)
+	assert.NotNil(b.OpenAction)
+}
+
+func TestOptOnStateChange(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Nil(b.OnStateChange)
+	OptOnStateChange(func(_ context.Context, from, to State, generation int64) {})(b)
+	assert.NotNil(b.OnStateChange)
+}
+
+func TestOptShouldCloseProvider(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Nil(b.ShouldCloseProvider)
+	OptShouldCloseProvider(func(ctx context.Context, counts Counts) bool { return false })(b)
+	assert.NotNil(b.ShouldCloseProvider)
+}
+
+func TestOptNowProvider(t *testing.T) {
+	assert := assert.New(t)
+
+	b := new(Breaker)
+	assert.Nil(b.NowProvider)
+	OptNowProvider(func() time.Time { return time.Now() })(b)
+	assert.NotNil(b.NowProvider)
+}

--- a/breaker/package.go
+++ b/breaker/package.go
@@ -1,0 +1,3 @@
+// Package breaker implements a basic state machine circuit breaker as
+// detailed in https://docs.microsoft.com/en-us/previous-versions/msp-n-p/dn589784(v=pandp.10)
+package breaker

--- a/breaker/state.go
+++ b/breaker/state.go
@@ -1,0 +1,27 @@
+package breaker
+
+import "fmt"
+
+// These constants are states of CircuitBreaker.
+const (
+	StateClosed State = iota
+	StateHalfOpen
+	StateOpen
+)
+
+// State is a type that represents a state of CircuitBreaker.
+type State int
+
+// String implements stringer interface.
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateHalfOpen:
+		return "half-open"
+	case StateOpen:
+		return "open"
+	default:
+		return fmt.Sprintf("unknown state: %d", s)
+	}
+}

--- a/breaker/state_test.go
+++ b/breaker/state_test.go
@@ -1,0 +1,20 @@
+package breaker
+
+import (
+	"testing"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestStateConstants(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(State(0), StateClosed)
+	assert.Equal(State(1), StateHalfOpen)
+	assert.Equal(State(2), StateOpen)
+
+	assert.Equal(StateClosed.String(), "closed")
+	assert.Equal(StateHalfOpen.String(), "half-open")
+	assert.Equal(StateOpen.String(), "open")
+	assert.Equal(State(100).String(), "unknown state: 100")
+}

--- a/examples/breaker/breaker/main.go
+++ b/examples/breaker/breaker/main.go
@@ -55,14 +55,14 @@ func main() {
 	var res interface{}
 	for x := 0; x < 1024; x++ {
 		if res, err = cb.Do(context.Background(), createCaller(mockServer.URL)); err != nil {
-			fmt.Printf("(%v) circuit breaker error: %v\n", cb.State(context.Background()), err)
+			fmt.Printf("(%v) circuit breaker error: %v\n", cb.EvaluateState(context.Background()), err)
 			if ex.Is(err, breaker.ErrOpenState) {
 				time.Sleep(5 * time.Second)
 			} else {
 				time.Sleep(100 * time.Millisecond)
 			}
 		} else {
-			fmt.Printf("(%v) result: %v\n", cb.State(context.Background()), res)
+			fmt.Printf("(%v) result: %v\n", cb.EvaluateState(context.Background()), res)
 			time.Sleep(100 * time.Millisecond)
 		}
 	}

--- a/examples/breaker/breaker/main.go
+++ b/examples/breaker/breaker/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/blend/go-sdk/ex"
+	"github.com/blend/go-sdk/webutil"
+
+	"github.com/blend/go-sdk/breaker"
+	"github.com/blend/go-sdk/r2"
+)
+
+// Result is a json thingy.
+type Result struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func createCaller(url string, opts ...r2.Option) breaker.Action {
+	return func(ctx context.Context) (interface{}, error) {
+		res, err := r2.New(url, opts...).Do()
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+		if res.StatusCode >= 300 {
+			return nil, fmt.Errorf("non 200 status code returned from remote")
+		}
+		var result Result
+		json.NewDecoder(res.Body).Decode(&result)
+		return result, nil
+	}
+}
+
+func main() {
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if rand.Float64() > 0.5 {
+			http.Error(rw, "should fail", http.StatusInternalServerError)
+			return
+		}
+		webutil.WriteJSON(rw, http.StatusOK, Result{1, "Foo"})
+		return
+	}))
+	defer mockServer.Close()
+
+	cb := breaker.MustNew(breaker.OptOpenExpiryInterval(5 * time.Second))
+	var err error
+	var res interface{}
+	for x := 0; x < 1024; x++ {
+		if res, err = cb.Do(context.Background(), createCaller(mockServer.URL)); err != nil {
+			fmt.Printf("(%v) circuit breaker error: %v\n", cb.State(context.Background()), err)
+			if ex.Is(err, breaker.ErrOpenState) {
+				time.Sleep(5 * time.Second)
+			} else {
+				time.Sleep(100 * time.Millisecond)
+			}
+		} else {
+			fmt.Printf("(%v) result: %v\n", cb.State(context.Background()), res)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}


### PR DESCRIPTION
## PR Summary

Adds a simple circuit breaker package. It is designed with making calls to flaky resources in mind, but does not constrain the caller to http calls (i.e. can be used to make any type of call that can be flaky).

 - **Type:** Features
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.