### PR TITLE
Fix transit key config object

### DIFF
--- a/secrets/types.go
+++ b/secrets/types.go
@@ -234,7 +234,7 @@ type CreateTransitKeyConfig struct {
 	//   ecdsa-p256 – ECDSA using the P-256 elliptic curve (asymmetric)
 	//   rsa-2048 - RSA with bit size of 2048 (asymmetric)
 	//   rsa-4096 - RSA with bit size of 4096 (asymmetric)
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 }
 
 // UpdateTransitKeyConfig is the configuration data for modifying a TransitKey


### PR DESCRIPTION
## PR Summary

I was a doofus and messed up some JSON tags. Didn't notice during my testing, since I was actually setting the type parameter when creating keys. It needs to be optional, so that it defaults correctly. sending { "type":"" } to vault is different then sending {}

 - **Type:** Bugfix
 - **Issue Link:** 
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.