### PR TITLE
Wcharczuk/r2 tweaks

### DIFF
--- a/examples/r2/logged/main.go
+++ b/examples/r2/logged/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	log := logger.MustNew(logger.OptAll())
 
-	err := r2.New("https://google.com/robots.txt",
+	_, err := r2.New("https://google.com/robots.txt",
 		r2.OptHeaderValue("X-Sent-By", "go-sdk/request2"),
 		r2.OptCookieValue("r2-ray-id", "baileydog01"),
 		r2.OptLogResponse(log),

--- a/examples/r2/mock/main_test.go
+++ b/examples/r2/mock/main_test.go
@@ -23,7 +23,7 @@ func (rf RequestFactory) Google() (*http.Response, error) {
 	return rf.New("https://google.com/robots.txt",
 		r2.OptUserAgent("blend go-sdk"),
 		r2.OptTimeout(5*time.Second),
-	).DiscardWithResponse()
+	).Discard()
 }
 
 func TestMockedRequest(t *testing.T) {

--- a/examples/r2/mtls/main.go
+++ b/examples/r2/mtls/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	log.Info("making a secure request")
 
-	if err := r2.New("https://localhost:5000",
+	if _, err := r2.New("https://localhost:5000",
 		r2.OptTLSRootCAs(caPool),
 		r2.OptTLSClientCert([]byte(clientKeyPair.Cert), []byte(clientKeyPair.Key))).Discard(); err != nil {
 		fatal(log, err)
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	log.Info("making an insecure request")
-	if err := r2.New("https://localhost:5000", r2.OptTLSRootCAs(caPool)).Discard(); err != nil {
+	if _, err := r2.New("https://localhost:5000", r2.OptTLSRootCAs(caPool)).Discard(); err != nil {
 		fatal(log, err)
 	}
 }

--- a/examples/r2/transport/main.go
+++ b/examples/r2/transport/main.go
@@ -19,7 +19,7 @@ func main() {
 	var res *http.Response
 	var err error
 	for x := 0; x < 10; x++ {
-		res, err = req.DiscardWithResponse()
+		res, err = req.Discard()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 		} else {

--- a/jobkit/management_server_test.go
+++ b/jobkit/management_server_test.go
@@ -29,12 +29,12 @@ func TestManagementServer(t *testing.T) {
 		},
 	})
 
-	meta, err := web.MockGet(app, "/").DiscardWithResponse()
+	meta, err := web.MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 
 	var jobs cron.Status
-	meta, err = web.MockGet(app, "/api/jobs").JSONWithResponse(&jobs)
+	meta, err = web.MockGet(app, "/api/jobs").JSON(&jobs)
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.Len(jobs.Jobs, 2)
@@ -55,13 +55,13 @@ func TestManagementServerHealthz(t *testing.T) {
 		},
 	})
 
-	meta, err := web.MockGet(app, "/healthz").DiscardWithResponse()
+	meta, err := web.MockGet(app, "/healthz").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 
 	jm.Stop()
 
-	meta, err = web.MockGet(app, "/healthz").DiscardWithResponse()
+	meta, err = web.MockGet(app, "/healthz").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusInternalServerError, meta.StatusCode)
 }
@@ -96,13 +96,13 @@ func TestManagementServerIndex(t *testing.T) {
 		},
 	})
 
-	contents, meta, err := web.MockGet(app, "/").BytesWithResponse()
+	contents, meta, err := web.MockGet(app, "/").Bytes()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.Contains(string(contents), jobName)
 	assert.Contains(string(contents), invocationID)
 
-	contents, meta, err = web.MockGet(app, fmt.Sprintf("/job.invocation/%s/%s", jobName, invocationID)).BytesWithResponse()
+	contents, meta, err = web.MockGet(app, fmt.Sprintf("/job.invocation/%s/%s", jobName, invocationID)).Bytes()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.Contains(string(contents), jobName)

--- a/r2/errors.go
+++ b/r2/errors.go
@@ -1,0 +1,11 @@
+package r2
+
+import (
+	"github.com/blend/go-sdk/ex"
+)
+
+// Error Constants
+const (
+	ErrNoContentJSON ex.Class = "server returned an http 204 for a request expecting json"
+	ErrNoContentXML  ex.Class = "server returned an http 204 for a request expecting xml"
+)

--- a/r2/opt_log_test.go
+++ b/r2/opt_log_test.go
@@ -24,6 +24,7 @@ func TestOptLog(t *testing.T) {
 	}))
 	defer server.Close()
 
-	assert.Nil(New(server.URL, OptLog(log)).Discard())
+	_, err = New(server.URL, OptLog(log)).Discard()
+	assert.Nil(err)
 	assert.NotEmpty(buf.String())
 }

--- a/r2/request.go
+++ b/r2/request.go
@@ -185,20 +185,8 @@ func (r Request) BytesWithResponse() ([]byte, *http.Response, error) {
 	return contents, res, nil
 }
 
-// JSON reads the response as json into a given object.
-func (r Request) JSON(dst interface{}) error {
-	defer r.Close()
-
-	res, err := r.Do()
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	return ex.New(json.NewDecoder(res.Body).Decode(dst))
-}
-
-// JSONWithResponse reads the response as json into a given object and returns the response metadata.
-func (r Request) JSONWithResponse(dst interface{}) (*http.Response, error) {
+// JSON reads the response as json into a given object and returns the response metadata.
+func (r Request) JSON(dst interface{}) (*http.Response, error) {
 	defer r.Close()
 
 	res, err := r.Do()
@@ -206,23 +194,14 @@ func (r Request) JSONWithResponse(dst interface{}) (*http.Response, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusNoContent {
+		return res, ex.New(ErrNoContentJSON)
+	}
 	return res, ex.New(json.NewDecoder(res.Body).Decode(dst))
 }
 
-// XML reads the response as json into a given object.
-func (r Request) XML(dst interface{}) error {
-	defer r.Close()
-
-	res, err := r.Do()
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	return ex.New(xml.NewDecoder(res.Body).Decode(dst))
-}
-
-// XMLWithResponse reads the response as json into a given object.
-func (r Request) XMLWithResponse(dst interface{}) (*http.Response, error) {
+// XML reads the response as xml into a given object and returns the response metadata.
+func (r Request) XML(dst interface{}) (*http.Response, error) {
 	defer r.Close()
 
 	res, err := r.Do()
@@ -230,5 +209,8 @@ func (r Request) XMLWithResponse(dst interface{}) (*http.Response, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusNoContent {
+		return res, ex.New(ErrNoContentXML)
+	}
 	return res, ex.New(xml.NewDecoder(res.Body).Decode(dst))
 }

--- a/r2/request.go
+++ b/r2/request.go
@@ -111,21 +111,8 @@ func (r *Request) Close() error {
 	return nil
 }
 
-// Discard reads the response fully and discards all data it reads.
-func (r *Request) Discard() error {
-	defer r.Close()
-
-	res, err := r.Do()
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	_, err = io.Copy(ioutil.Discard, res.Body)
-	return ex.New(err)
-}
-
-// DiscardWithResponse reads the response fully and discards all data it reads, and returns the response metadata.
-func (r Request) DiscardWithResponse() (*http.Response, error) {
+// Discard reads the response fully and discards all data it reads, and returns the response metadata.
+func (r Request) Discard() (*http.Response, error) {
 	defer r.Close()
 
 	res, err := r.Do()
@@ -153,24 +140,8 @@ func (r Request) CopyTo(dst io.Writer) (int64, error) {
 	return count, nil
 }
 
-// Bytes reads the response and returns it as a byte array.
-func (r Request) Bytes() ([]byte, error) {
-	defer r.Close()
-
-	res, err := r.Do()
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-	contents, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, ex.New(err)
-	}
-	return contents, nil
-}
-
-// BytesWithResponse reads the response and returns it as a byte array, along with the response metadata..
-func (r Request) BytesWithResponse() ([]byte, *http.Response, error) {
+// Bytes reads the response and returns it as a byte array, along with the response metadata..
+func (r Request) Bytes() ([]byte, *http.Response, error) {
 	defer r.Close()
 
 	res, err := r.Do()

--- a/r2/request_test.go
+++ b/r2/request_test.go
@@ -128,14 +128,7 @@ func TestRequestDiscard(t *testing.T) {
 	assert := assert.New(t)
 	server := mockServerOK()
 	defer server.Close()
-	assert.Nil(New(server.URL).Discard())
-}
-
-func TestRequestDiscardWithResponse(t *testing.T) {
-	assert := assert.New(t)
-	server := mockServerOK()
-	defer server.Close()
-	res, err := New(server.URL).DiscardWithResponse()
+	res, err := New(server.URL).Discard()
 	assert.Nil(err)
 	assert.NotNil(res)
 }
@@ -154,16 +147,7 @@ func TestRequestBytes(t *testing.T) {
 	assert := assert.New(t)
 	server := mockServerOK()
 	defer server.Close()
-	contents, err := New(server.URL).Bytes()
-	assert.Nil(err)
-	assert.Equal("OK!\n", contents)
-}
-
-func TestRequestBytesWithResponse(t *testing.T) {
-	assert := assert.New(t)
-	server := mockServerOK()
-	defer server.Close()
-	contents, meta, err := New(server.URL).BytesWithResponse()
+	contents, meta, err := New(server.URL).Bytes()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.Equal("OK!\n", contents)
@@ -246,7 +230,9 @@ func TestRequestTracer(t *testing.T) {
 			didCallFinish = true
 		},
 	}
-	assert.Nil(New(server.URL, OptTracer(tracer)).Discard())
+
+	_, err := New(server.URL, OptTracer(tracer)).Discard()
+	assert.Nil(err)
 	assert.True(didCallStart)
 	assert.True(didCallFinish)
 }
@@ -258,7 +244,7 @@ func TestRequestListeners(t *testing.T) {
 	defer server.Close()
 
 	var didCallRequest1, didCallRequest2, didCallResponse1, didCallResponse2 bool
-	assert.Nil(New(server.URL,
+	_, err := New(server.URL,
 		OptOnRequest(func(_ *http.Request) error {
 			didCallRequest1 = true
 			return nil
@@ -275,7 +261,8 @@ func TestRequestListeners(t *testing.T) {
 			didCallResponse2 = true
 			return nil
 		}),
-	).Discard())
+	).Discard()
+	assert.Nil(err)
 	assert.True(didCallRequest1)
 	assert.True(didCallRequest2)
 	assert.True(didCallResponse1)

--- a/web/app_test.go
+++ b/web/app_test.go
@@ -113,7 +113,7 @@ func TestAppPathParams(t *testing.T) {
 	assert.Equal("foo", params.Get("uuid"))
 	assert.False(skipSlashRedirect)
 
-	meta, err := MockGet(app, "/foo").DiscardWithResponse()
+	meta, err := MockGet(app, "/foo").Discard()
 	assert.Nil(err, fmt.Sprintf("%+v", err))
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.NotNil(route)
@@ -144,7 +144,7 @@ func TestAppPathParamsForked(t *testing.T) {
 		return Raw([]byte("ok!"))
 	})
 
-	meta, err := MockGet(app, "/foos/bar/foo").DiscardWithResponse()
+	meta, err := MockGet(app, "/foos/bar/foo").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.NotNil(route)
@@ -244,7 +244,7 @@ func TestAppMiddleWarePipeline(t *testing.T) {
 		},
 	)
 
-	result, err := MockGet(app, "/").Bytes()
+	result, _, err := MockGet(app, "/").Bytes()
 	assert.Nil(err)
 	assert.True(didRun)
 	assert.Equal("foo", string(result))
@@ -258,7 +258,7 @@ func TestAppStatic(t *testing.T) {
 
 	app.ServeStatic("/static/*filepath", []string{"testdata"})
 
-	index, err := MockGet(app, "/static/test_file.html").Bytes()
+	index, _, err := MockGet(app, "/static/test_file.html").Bytes()
 	assert.Nil(err)
 	assert.True(strings.Contains(string(index), "Test!"), string(index))
 }
@@ -272,7 +272,7 @@ func TestAppStaticSingleFile(t *testing.T) {
 		return Static("testdata/test_file.html")
 	})
 
-	index, err := MockGet(app, "/").Bytes()
+	index, _, err := MockGet(app, "/").Bytes()
 	assert.Nil(err)
 	assert.True(strings.Contains(string(index), "Test!"), string(index))
 }
@@ -290,7 +290,7 @@ func TestAppProviderMiddleware(t *testing.T) {
 
 	app.GET("/", okAction, JSONProviderAsDefault)
 
-	err = MockGet(app, "/").Discard()
+	_, err = MockGet(app, "/").Discard()
 	assert.Nil(err)
 }
 
@@ -313,7 +313,8 @@ func TestAppProviderMiddlewareOrder(t *testing.T) {
 	}
 
 	app.GET("/", okAction, dependsOnProvider, JSONProviderAsDefault)
-	assert.Nil(MockGet(app, "/").Discard())
+	_, err = MockGet(app, "/").Discard()
+	assert.Nil(err)
 }
 
 func TestAppDefaultResultProvider(t *testing.T) {
@@ -346,7 +347,8 @@ func TestAppDefaultResultProviderWithDefault(t *testing.T) {
 		assert.True(isTyped)
 		return nil
 	})
-	assert.Nil(MockGet(app, "/").Discard())
+	_, err = MockGet(app, "/").Discard()
+	assert.Nil(err)
 }
 
 func TestAppDefaultResultProviderWithDefaultFromRoute(t *testing.T) {
@@ -359,7 +361,7 @@ func TestAppDefaultResultProviderWithDefaultFromRoute(t *testing.T) {
 	app.GET("/", controllerNoOp, SessionRequired, ViewProviderAsDefault)
 
 	//somehow assert that the content type is html
-	meta, err := MockGet(app, "/").DiscardWithResponse()
+	meta, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	defer meta.Body.Close()
 
@@ -377,7 +379,7 @@ func TestAppViewResult(t *testing.T) {
 		return r.Views.View("test", "foobarbaz")
 	})
 
-	contents, meta, err := MockGet(app, "/").BytesWithResponse()
+	contents, meta, err := MockGet(app, "/").Bytes()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode, string(contents))
 	assert.Equal(ContentTypeHTML, meta.Header.Get(HeaderContentType))
@@ -396,7 +398,7 @@ func TestAppWritesLogs(t *testing.T) {
 	app.GET("/", func(r *Ctx) Result {
 		return Raw([]byte("ok!"))
 	})
-	err = MockGet(app, "/").Discard()
+	_, err = MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Nil(agent.Drain())
 
@@ -432,7 +434,7 @@ func TestAppNotFound(t *testing.T) {
 		defer wg.Done()
 		return JSON.NotFound()
 	})
-	err = MockGet(app, "/doesntexist").Discard()
+	_, err = MockGet(app, "/doesntexist").Discard()
 	assert.Nil(err)
 	wg.Wait()
 }
@@ -447,7 +449,7 @@ func TestAppDefaultHeaders(t *testing.T) {
 		return Text.Result("ok")
 	})
 
-	meta, err := MockGet(app, "/").DiscardWithResponse()
+	meta, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.NotEmpty(meta.Header)
 	assert.Equal("bar", meta.Header.Get("foo"))
@@ -465,7 +467,8 @@ func TestAppViewErrorsRenderErrorView(t *testing.T) {
 	app.GET("/", func(r *Ctx) Result {
 		return r.Views.View("malformed", nil)
 	})
-	assert.NotNil(MockGet(app, "/").Discard())
+	_, err = MockGet(app, "/").Discard()
+	assert.NotNil(err)
 }
 
 func TestAppAddsDefaultHeaders(t *testing.T) {
@@ -586,7 +589,8 @@ func TestAppTracer(t *testing.T) {
 		},
 	}
 
-	assert.Nil(MockGet(app, "/").Discard())
+	_, err = MockGet(app, "/").Discard()
+	assert.Nil(err)
 	wg.Wait()
 
 	assert.True(hasValue)
@@ -612,7 +616,8 @@ func TestAppTracerError(t *testing.T) {
 		},
 	}
 
-	assert.Nil(MockGet(app, "/error").Discard())
+	_, err = MockGet(app, "/error").Discard()
+	assert.Nil(err)
 	wg.Wait()
 	assert.True(hasError)
 }
@@ -645,7 +650,8 @@ func TestAppViewTracer(t *testing.T) {
 		},
 	}
 
-	assert.Nil(MockGet(app, "/view").Discard())
+	_, err = MockGet(app, "/view").Discard()
+	assert.Nil(err)
 	wg.Wait()
 
 	assert.True(hasValue)
@@ -679,8 +685,8 @@ func TestAppViewTracerError(t *testing.T) {
 			hasViewError = err != nil
 		},
 	}
-
-	assert.Nil(MockGet(app, "/view").Discard())
+	_, err = MockGet(app, "/view").Discard()
+	assert.Nil(err)
 	wg.Wait()
 
 	assert.True(hasValue)

--- a/web/gzip_middleware_test.go
+++ b/web/gzip_middleware_test.go
@@ -19,7 +19,7 @@ func TestGZipMiddlewarePlaintext(t *testing.T) {
 
 	req := MockGet(app, "/")
 	assert.Nil(req.Err)
-	resBody, err := req.Bytes()
+	resBody, _, err := req.Bytes()
 	assert.Nil(err)
 	assert.Equal("\"OK!\"\n", string(resBody))
 }
@@ -34,7 +34,7 @@ func TestGZipMiddlewareCompressed(t *testing.T) {
 
 	req := MockGet(app, "/", r2.OptHeaderValue(HeaderAcceptEncoding, "gzip"))
 	assert.Nil(req.Err)
-	body, meta, err := req.BytesWithResponse()
+	body, meta, err := req.Bytes()
 
 	assert.Equal("gzip", meta.Header.Get(HeaderContentEncoding))
 	assert.Equal("Accept-Encoding", meta.Header.Get(HeaderVary))

--- a/web/mock_test.go
+++ b/web/mock_test.go
@@ -14,7 +14,7 @@ func TestMock(t *testing.T) {
 	app := MustNew()
 	app.GET("/", func(_ *Ctx) Result { return NoContent })
 
-	res, err := Mock(app, &http.Request{Method: "GET", URL: &url.URL{Scheme: SchemeHTTP, Path: "/"}}).DiscardWithResponse()
+	res, err := Mock(app, &http.Request{Method: "GET", URL: &url.URL{Scheme: SchemeHTTP, Path: "/"}}).Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusNoContent, res.StatusCode)
 
@@ -27,7 +27,7 @@ func TestMockGet(t *testing.T) {
 	app := MustNew()
 	app.GET("/", func(_ *Ctx) Result { return NoContent })
 
-	res, err := MockGet(app, "/").DiscardWithResponse()
+	res, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusNoContent, res.StatusCode)
 

--- a/web/session_middleware_test.go
+++ b/web/session_middleware_test.go
@@ -27,14 +27,14 @@ func TestSessionAware(t *testing.T) {
 		return Text.Result("COOL")
 	}, SessionAware)
 
-	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).DiscardWithResponse()
+	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.Equal(ContentTypeText, meta.Header.Get(HeaderContentType))
 	assert.True(didExecuteHandler, "we should have triggered the hander")
 	assert.True(sessionWasSet, "the session should have been set by the middleware")
 
-	unsetMeta, err := MockGet(app, "/").DiscardWithResponse()
+	unsetMeta, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, unsetMeta.StatusCode)
 	assert.False(sessionWasSet)
@@ -54,12 +54,12 @@ func TestSessionRequired(t *testing.T) {
 		return Text.Result("COOL")
 	}, SessionRequired)
 
-	unsetMeta, err := MockGet(app, "/").DiscardWithResponse()
+	unsetMeta, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusUnauthorized, unsetMeta.StatusCode)
 	assert.False(sessionWasSet)
 
-	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).DiscardWithResponse()
+	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.True(sessionWasSet)
@@ -80,17 +80,17 @@ func TestSessionRequiredCustomParamName(t *testing.T) {
 		return Text.Result("COOL")
 	}, SessionRequired)
 
-	unsetMeta, err := MockGet(app, "/").DiscardWithResponse()
+	unsetMeta, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusUnauthorized, unsetMeta.StatusCode)
 	assert.False(sessionWasSet)
 
-	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).DiscardWithResponse()
+	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.True(sessionWasSet)
 
-	meta, err = MockGet(app, "/", r2.OptCookieValue(DefaultCookieName, sessionID)).DiscardWithResponse()
+	meta, err = MockGet(app, "/", r2.OptCookieValue(DefaultCookieName, sessionID)).Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusUnauthorized, meta.StatusCode)
 	assert.True(sessionWasSet)
@@ -118,12 +118,12 @@ func TestSessionMiddleware(t *testing.T) {
 		return NoContent
 	}))
 
-	unsetMeta, err := MockGet(app, "/").DiscardWithResponse()
+	unsetMeta, err := MockGet(app, "/").Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusNoContent, unsetMeta.StatusCode)
 	assert.False(sessionWasSet)
 
-	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).DiscardWithResponse()
+	meta, err := MockGet(app, "/", r2.OptCookieValue(app.Auth.CookieDefaults.Name, sessionID)).Discard()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode)
 	assert.True(sessionWasSet)

--- a/web/view_model_test.go
+++ b/web/view_model_test.go
@@ -20,7 +20,7 @@ func TestViewModelWrap(t *testing.T) {
 		return r.Views.View("index", []string{"foo", "bar", "baz"})
 	})
 
-	contents, meta, err := MockGet(app, "/").BytesWithResponse()
+	contents, meta, err := MockGet(app, "/").Bytes()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode, string(contents))
 	assert.Equal("<div>foo</div><div>bar</div><div>baz</div>", string(contents))


### PR DESCRIPTION
## PR Summary

Changes the behavior of `r2.Request` to return the response meta by default for most methods, removing various instances of `WithResponse` overloads.

 - **Type:** Internal
 - **Intended Change Level:** major

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.