### PR TITLE
Assert IndirectEqual

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1244,10 +1244,10 @@ func areReferenceEqual(expected, actual interface{}) bool {
 }
 
 func areIndirectEqual(expected, actual interface{}) bool {
-	if expected == nil && actual == nil {
+	if isNil(expected) && isNil(actual) {
 		return true
 	}
-	if (expected == nil && actual != nil) || (expected != nil && actual == nil) {
+	if (isNil(expected) && !isNil(actual)) || (!isNil(expected) && isNil(actual)) {
 		return false
 	}
 

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -615,6 +615,66 @@ func TestAssertReferenceEqual(t *testing.T) {
 	}
 }
 
+func TestAssertIndirectEqual(t *testing.T) {
+	obj1 := "foo"
+	obj2 := "foo"
+	obj3 := "bar"
+	ref1 := &obj1
+	ref2 := &obj1
+	ref3 := &obj2
+	ref4 := &obj3
+
+	passCases := [][]interface{}{
+		[]interface{}{ref1, ref2},
+		[]interface{}{ref1, ref3},
+		[]interface{}{nil, nil},
+	}
+
+	failCases := [][]interface{}{
+		[]interface{}{ref1, ref4},
+		[]interface{}{ref1, nil},
+	}
+
+	for i, passCase := range passCases {
+		err := safeExec(func() {
+			New(nil).IndirectEqual(passCase[0], passCase[1])
+			New(nil).IndirectEqual(passCase[1], passCase[0])
+		})
+		if err != nil {
+			t.Errorf("should not have produced a panic on pass case index %d", i)
+			t.FailNow()
+		}
+	}
+
+	for i, failCase := range failCases {
+		output := bytes.NewBuffer(nil)
+		err := safeExec(func() {
+			New(nil).WithOutput(output).IndirectEqual(failCase[0], failCase[1])
+		})
+		if err == nil {
+			t.Errorf("should have produced a panic on fail case idnex %d", i)
+			t.FailNow()
+		}
+		if len(output.String()) == 0 {
+			t.Errorf("Should have written output on failure on fail case index %d", i)
+			t.FailNow()
+		}
+
+		output = bytes.NewBuffer(nil)
+		err = safeExec(func() {
+			New(nil).WithOutput(output).IndirectEqual(failCase[1], failCase[0])
+		})
+		if err == nil {
+			t.Errorf("should have produced a panic on fail case idnex %d", i)
+			t.FailNow()
+		}
+		if len(output.String()) == 0 {
+			t.Errorf("Should have written output on failure on fail case index %d", i)
+			t.FailNow()
+		}
+	}
+}
+
 func TestAssertNotEqual(t *testing.T) {
 	err := safeExec(func() {
 		New(nil).NotEqual("foo", "bar") // should be ok

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -627,12 +627,12 @@ func TestAssertIndirectEqual(t *testing.T) {
 	passCases := [][]interface{}{
 		[]interface{}{ref1, ref2},
 		[]interface{}{ref1, ref3},
-		[]interface{}{nil, nil},
+		[]interface{}{(*string)(nil), (*string)(nil)},
 	}
 
 	failCases := [][]interface{}{
 		[]interface{}{ref1, ref4},
-		[]interface{}{ref1, nil},
+		[]interface{}{ref1, (*string)(nil)},
 	}
 
 	for i, passCase := range passCases {


### PR DESCRIPTION
## PR Summary

Adds an assert function for checking equality pointers if nil, and if not then checks the equality of the values that the pointers point to

 - **Type:** Improvements
 - **Issue Link:** https://github.com/blend/go-sdk/issues/??
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.