### PR TITLE
Add NotEmpty validator to Any

### DIFF
--- a/validate/any.go
+++ b/validate/any.go
@@ -13,6 +13,7 @@ const (
 	ErrRequired   ex.Class = "field is required"
 	ErrForbidden  ex.Class = "field is forbidden"
 	ErrEmpty      ex.Class = "object should be empty"
+	ErrNotEmpty   ex.Class = "object should not be empty"
 	ErrLen        ex.Class = "object should have a given length"
 	ErrNil        ex.Class = "object should be nil"
 	ErrNotNil     ex.Class = "object should not be nil"
@@ -94,6 +95,21 @@ func (a AnyValidators) Empty() Validator {
 			return nil
 		}
 		return Error(ErrEmpty, a.Obj)
+	}
+}
+
+// NotEmpty returns if a slice, map or channel is not empty.
+// It will error if the object is not a slice, map or channel.
+func (a AnyValidators) NotEmpty() Validator {
+	return func() error {
+		objLen, err := GetLength(a.Obj)
+		if err != nil {
+			return err
+		}
+		if objLen > 0 {
+			return nil
+		}
+		return Error(ErrNotEmpty, a.Obj)
 	}
 }
 

--- a/validate/any_test.go
+++ b/validate/any_test.go
@@ -169,6 +169,69 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
+func TestNotEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := [...]struct {
+		Input    interface{}
+		Expected error
+	}{
+		{
+			Input:    nil,
+			Expected: ErrNonLengthType,
+		},
+		{
+			Input:    0,
+			Expected: ErrNonLengthType,
+		},
+		{
+			Input:    []string{},
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    ([]string)(nil),
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    map[string]interface{}{},
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    (map[string]interface{})(nil),
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    "",
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    make(chan struct{}),
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    (chan struct{})(nil),
+			Expected: ErrNotEmpty,
+		},
+		{
+			Input:    []string{"a", "b"},
+			Expected: nil,
+		},
+		{
+			Input:    map[string]int{"hi": 1},
+			Expected: nil,
+		},
+		{
+			Input:    "foo",
+			Expected: nil,
+		},
+	}
+
+	for index, tc := range testCases {
+		verr := Any(tc.Input).NotEmpty()()
+		assert.Equal(tc.Expected, Cause(verr), index)
+	}
+}
+
 func TestLen(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
## PR Summary

Add not empty validator to any

 - **Type:** Improvements
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.