### PR TITLE
moved the secrets mock http client into its own file

### DIFF
--- a/secrets/main_test.go
+++ b/secrets/main_test.go
@@ -1,51 +1,12 @@
 package secrets
 
 import (
-	"bytes"
-	"fmt"
-	"github.com/blend/go-sdk/assert"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 	"testing"
+
+	"github.com/blend/go-sdk/assert"
 )
 
 // TestMain is the testing entrypoint.
 func TestMain(m *testing.M) {
 	assert.Main(m)
-}
-
-// NewMockHTTPClient returns a new mock http client.
-func NewMockHTTPClient() *MockHTTPClient {
-	return &MockHTTPClient{
-		contents: make(map[string]*http.Response),
-	}
-}
-
-// MockHTTPClient is a mock http client.
-type MockHTTPClient struct {
-	contents map[string]*http.Response
-}
-
-// With adds a mocked endpoint.
-func (mh *MockHTTPClient) With(verb string, url *url.URL, response *http.Response) *MockHTTPClient {
-	mh.contents[fmt.Sprintf("%s_%s", verb, url.String())] = response
-	return mh
-}
-
-// WithString adds a mocked endpoint.
-func (mh *MockHTTPClient) WithString(verb string, url *url.URL, contents string) *MockHTTPClient {
-	mh.contents[fmt.Sprintf("%s_%s", verb, url.String())] = &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(contents))),
-	}
-	return mh
-}
-
-// Do implements HTTPClient.
-func (mh *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	if res, hasRes := mh.contents[fmt.Sprintf("%s_%s", req.Method, req.URL.String())]; hasRes {
-		return res, nil
-	}
-	return nil, fmt.Errorf("not found")
 }

--- a/secrets/mock_http_client.go
+++ b/secrets/mock_http_client.go
@@ -1,0 +1,44 @@
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// NewMockHTTPClient returns a new mock http client.
+func NewMockHTTPClient() *MockHTTPClient {
+	return &MockHTTPClient{
+		contents: make(map[string]*http.Response),
+	}
+}
+
+// MockHTTPClient is a mock http client.
+type MockHTTPClient struct {
+	contents map[string]*http.Response
+}
+
+// With adds a mocked endpoint.
+func (mh *MockHTTPClient) With(verb string, url *url.URL, response *http.Response) *MockHTTPClient {
+	mh.contents[fmt.Sprintf("%s_%s", verb, url.String())] = response
+	return mh
+}
+
+// WithString adds a mocked endpoint.
+func (mh *MockHTTPClient) WithString(verb string, url *url.URL, contents string) *MockHTTPClient {
+	mh.contents[fmt.Sprintf("%s_%s", verb, url.String())] = &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(contents))),
+	}
+	return mh
+}
+
+// Do implements HTTPClient.
+func (mh *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if res, hasRes := mh.contents[fmt.Sprintf("%s_%s", req.Method, req.URL.String())]; hasRes {
+		return res, nil
+	}
+	return nil, fmt.Errorf("not found")
+}

--- a/secrets/mock_http_client_test.go
+++ b/secrets/mock_http_client_test.go
@@ -1,0 +1,35 @@
+package secrets
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestMockHTTPClientDo(t *testing.T) {
+	assert := assert.New(t)
+
+	// mocked request and response
+	address := "www.blend.com"
+	url, err := url.Parse(address)
+	assert.Nil(err)
+
+	client := NewMockHTTPClient()
+
+	// Test: Do returns the OK response matching the route specified
+	happyReq, err := http.NewRequest(http.MethodGet, address, bytes.NewReader([]byte{}))
+	happyResp := &http.Response{StatusCode: http.StatusOK}
+	assert.Nil(err)
+	r, err := client.With(http.MethodGet, url, happyResp).Do(happyReq)
+	assert.Nil(err)
+	assert.Equal(happyResp, r)
+
+	// Test: Do returns an error response for unknown routes
+	badReq, err := http.NewRequest(http.MethodDelete, address, bytes.NewReader([]byte{}))
+	r, err = client.Do(badReq)
+	assert.NotNil(err)
+	assert.Nil(r)
+}


### PR DESCRIPTION
## PR Summary

Moved the secrets mock http client into its own file and added a basic test/example.

 - **Type:** Internal
 - **Issue Link:** n/a
 - **Intended Change Level:** minor

