### PR TITLE
Added subject common name to TLS certificate information

### DIFF
--- a/request/cert_info.go
+++ b/request/cert_info.go
@@ -34,10 +34,11 @@ func NewCertInfo(res *http.Response) *CertInfo {
 		}
 
 		return &CertInfo{
-			DNSNames:         firstCert.DNSNames,
-			NotAfter:         earliestExpiration,
-			NotBefore:        latestNotBefore,
-			IssuerCommonName: issuerCommonName,
+			DNSNames:          firstCert.DNSNames,
+			NotAfter:          earliestExpiration,
+			NotBefore:         latestNotBefore,
+			IssuerCommonName:  issuerCommonName,
+			SubjectCommonName: firstCert.Subject.CommonName,
 		}
 	}
 
@@ -46,8 +47,9 @@ func NewCertInfo(res *http.Response) *CertInfo {
 
 // CertInfo is the information for a certificate.
 type CertInfo struct {
-	IssuerCommonName string    `json:"issuerCommonName" yaml:"issuerCommonName"`
-	DNSNames         []string  `json:"dnsNames" yaml:"dnsNames"`
-	NotAfter         time.Time `json:"notAfter" yaml:"notAfter"`
-	NotBefore        time.Time `json:"notBefore" yaml:"notBefore"`
+	IssuerCommonName  string    `json:"issuerCommonName" yaml:"issuerCommonName"`
+	SubjectCommonName string    `json:"subjectCommonName" yaml:"subjectCommonName"`
+	DNSNames          []string  `json:"dnsNames" yaml:"dnsNames"`
+	NotAfter          time.Time `json:"notAfter" yaml:"notAfter"`
+	NotBefore         time.Time `json:"notBefore" yaml:"notBefore"`
 }

--- a/request/cert_info_test.go
+++ b/request/cert_info_test.go
@@ -1,0 +1,46 @@
+package request
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestNewCertInfo(t *testing.T) {
+	assert := assert.New(t)
+
+	notBefore, notAfter := time.Now(), time.Now()
+	issuer := "go-sdk tests"
+	subject := "test.blend.com"
+	dnsNames := []string{subject}
+	response := &http.Response{
+		TLS: &tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{
+				&x509.Certificate{
+					Issuer: pkix.Name{
+						CommonName: issuer,
+					},
+					Subject: pkix.Name{
+						CommonName: subject,
+					},
+					DNSNames:  dnsNames,
+					NotBefore: notBefore,
+					NotAfter:  notAfter,
+				},
+			},
+		},
+	}
+
+	// Test: NewCertInfo should include dns names, validity periods, issuer and subject common names
+	certInfo := NewCertInfo(response)
+	assert.Equal(dnsNames, certInfo.DNSNames)
+	assert.Equal(notBefore, certInfo.NotBefore)
+	assert.Equal(notAfter, certInfo.NotAfter)
+	assert.Equal(issuer, certInfo.IssuerCommonName)
+	assert.Equal(subject, certInfo.SubjectCommonName)
+}


### PR DESCRIPTION
## PR Summary

This PR updates the certificate information that is appended to a request's response to include the certificate subject's common name.

 - **Type:** Improvements
 - **Intended Change Level:** patch