### PR TITLE
Fix constant name

### DIFF
--- a/sentry/listener.go
+++ b/sentry/listener.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// ListenerName is the sentry listener name.
-	ListenerName = "airbrake"
+	ListenerName = "sentry"
 )
 
 // AddListeners adds error listeners.


### PR DESCRIPTION
## PR Summary

The constant identifier for the sentry listener is currently listed as "airbrake". Some research (ref: http://www.math.harvard.edu/~mazur/preprints/when_is_one.pdf) has led me to realize this is not equal to "sentry," so I have made the appropriate changes.

 - **Type:** Bugfix
 - **Issue Link:** N/A
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.