### PR TITLE
Update `cmd/recover` to only resolve `bin` on `PATH` once

### DIFF
--- a/cmd/recover/main.go
+++ b/cmd/recover/main.go
@@ -70,8 +70,8 @@ func runLoop(quit chan os.Signal, pwd string, subCommand ...string) error {
 		select {
 		case <-alarm:
 			break
-		case <-quit:
-			verbosef("received SIGINT during delay, exiting")
+		case s := <-quit:
+			verbosef("received SIGINT (%s) during delay, exiting", s)
 			return nil
 		}
 	}
@@ -98,8 +98,8 @@ func runLoop(quit chan os.Signal, pwd string, subCommand ...string) error {
 		// kick off monitor
 		go func() {
 			select {
-			case <-quit:
-				verbosef("received SIGINT while sub process is running, killing sub process")
+			case s := <-quit:
+				verbosef("received SIGINT (%s) while sub process is running, killing sub process", s)
 				didQuit = true
 				sub.Process.Kill()
 				return
@@ -130,8 +130,8 @@ func runLoop(quit chan os.Signal, pwd string, subCommand ...string) error {
 			select {
 			case <-alarm:
 				continue
-			case <-quit:
-				verbosef("received SIGINT during wait, exiting")
+			case s := <-quit:
+				verbosef("received SIGINT (%s) during wait, exiting", s)
 				return nil
 			}
 		}


### PR DESCRIPTION
## PR Summary

The current implementation 

 - **Type:** Improvements
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.