### PR TITLE
Setting content length in many cases where `req.Body` is set.

### DIFF
--- a/r2/request.go
+++ b/r2/request.go
@@ -63,12 +63,10 @@ func (r Request) Do() (*http.Response, error) {
 	}
 
 	// reconcile post form values
-	if r.Request.PostForm != nil && len(r.Request.PostForm) > 0 {
-		if r.Request.Body == nil {
-			body := r.Request.PostForm.Encode()
-			r.Request.Body = ioutil.NopCloser(strings.NewReader(body))
-			r.Request.ContentLength = int64(len(body))
-		}
+	if r.Request.PostForm != nil && len(r.Request.PostForm) > 0 && r.Request.Body == nil {
+		body := r.Request.PostForm.Encode()
+		r.Request.Body = ioutil.NopCloser(strings.NewReader(body))
+		r.Request.ContentLength = int64(len(body))
 	}
 
 	var err error

--- a/r2/request.go
+++ b/r2/request.go
@@ -65,7 +65,9 @@ func (r Request) Do() (*http.Response, error) {
 	// reconcile post form values
 	if r.Request.PostForm != nil && len(r.Request.PostForm) > 0 {
 		if r.Request.Body == nil {
-			r.Request.Body = ioutil.NopCloser(strings.NewReader(r.Request.PostForm.Encode()))
+			body := r.Request.PostForm.Encode()
+			r.Request.Body = ioutil.NopCloser(strings.NewReader(body))
+			r.Request.ContentLength = int64(len(body))
 		}
 	}
 

--- a/r2/request_test.go
+++ b/r2/request_test.go
@@ -124,7 +124,7 @@ func TestRequestDoPostForm(t *testing.T) {
 	).Do()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, res.StatusCode, readString(res.Body))
-	assert.Equal(reqContentLength, []int64{-1})
+	assert.Equal(reqContentLength, []int64{7})
 }
 
 func TestRequestDiscard(t *testing.T) {

--- a/r2/request_test.go
+++ b/r2/request_test.go
@@ -100,7 +100,9 @@ func TestRequestDoQuery(t *testing.T) {
 func TestRequestDoPostForm(t *testing.T) {
 	assert := assert.New(t)
 
+	var reqContentLength []int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqContentLength = append(reqContentLength, r.ContentLength)
 		if err := r.ParseForm(); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "%v!\n", err)
@@ -122,6 +124,7 @@ func TestRequestDoPostForm(t *testing.T) {
 	).Do()
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, res.StatusCode, readString(res.Body))
+	assert.Equal(reqContentLength, []int64{-1})
 }
 
 func TestRequestDiscard(t *testing.T) {

--- a/webutil/request_option.go
+++ b/webutil/request_option.go
@@ -193,6 +193,7 @@ func OptBody(contents io.ReadCloser) RequestOption {
 func OptBodyBytes(body []byte) RequestOption {
 	return func(r *http.Request) error {
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		r.ContentLength = int64(len(body))
 		return nil
 	}
 }
@@ -237,6 +238,7 @@ func OptJSONBody(obj interface{}) RequestOption {
 		}
 		r.Header.Set(HeaderContentType, ContentTypeApplicationJSON)
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(contents))
+		r.ContentLength = int64(len(contents))
 		return nil
 	}
 }
@@ -253,6 +255,7 @@ func OptXMLBody(obj interface{}) RequestOption {
 		}
 		r.Header.Set(HeaderContentType, ContentTypeApplicationXML)
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(contents))
+		r.ContentLength = int64(len(contents))
 		return nil
 	}
 }

--- a/webutil/request_option_test.go
+++ b/webutil/request_option_test.go
@@ -137,7 +137,7 @@ func TestOptBodyBytes(t *testing.T) {
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	assert.Nil(err)
 	assert.Equal(bodyBytes, body)
-	assert.Equal(r.ContentLength, 0)
+	assert.Equal(r.ContentLength, 6)
 }
 
 func TestOptJSONBody(t *testing.T) {
@@ -153,7 +153,7 @@ func TestOptJSONBody(t *testing.T) {
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	assert.Nil(err)
 	assert.Equal(bodyBytes, []byte(`{"x":1.25,"y":-5.75}`))
-	assert.Equal(r.ContentLength, 0)
+	assert.Equal(r.ContentLength, 20)
 }
 
 func TestOptXMLBody(t *testing.T) {
@@ -169,5 +169,5 @@ func TestOptXMLBody(t *testing.T) {
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	assert.Nil(err)
 	assert.Equal(bodyBytes, []byte("<xmlBody><x>hello</x><y>goodbye</y></xmlBody>"))
-	assert.Equal(r.ContentLength, 0)
+	assert.Equal(r.ContentLength, 45)
 }

--- a/webutil/request_option_test.go
+++ b/webutil/request_option_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/blend/go-sdk/assert"
 )
 
+type xmlBody struct {
+	X []string `xml:"x"`
+	Y []string `xml:"y"`
+}
+
 func TestRequestOptions(t *testing.T) {
 	assert := assert.New(t)
 
@@ -118,4 +123,51 @@ func TestRequestOptions(t *testing.T) {
 	assert.Nil(OptXMLBody([]string{"foo", "bar"})(req))
 	assert.Equal(ContentTypeApplicationXML, req.Header.Get(HeaderContentType))
 	assert.NotNil(req.Body)
+}
+
+func TestOptBodyBytes(t *testing.T) {
+	assert := assert.New(t)
+	body := []byte("hello\n")
+	opt := OptBodyBytes(body)
+
+	r := &http.Request{}
+	err := opt(r)
+	assert.Nil(err)
+
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	assert.Nil(err)
+	assert.Equal(bodyBytes, body)
+	assert.Equal(r.ContentLength, 0)
+}
+
+func TestOptJSONBody(t *testing.T) {
+	assert := assert.New(t)
+	payload := map[string]float64{"x": 1.25, "y": -5.75}
+	opt := OptJSONBody(payload)
+
+	r := &http.Request{}
+	err := opt(r)
+	assert.Nil(err)
+
+	assert.Equal(r.Header, http.Header{HeaderContentType: []string{ContentTypeApplicationJSON}})
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	assert.Nil(err)
+	assert.Equal(bodyBytes, []byte(`{"x":1.25,"y":-5.75}`))
+	assert.Equal(r.ContentLength, 0)
+}
+
+func TestOptXMLBody(t *testing.T) {
+	assert := assert.New(t)
+	payload := xmlBody{X: []string{"hello"}, Y: []string{"goodbye"}}
+	opt := OptXMLBody(payload)
+
+	r := &http.Request{}
+	err := opt(r)
+	assert.Nil(err)
+
+	assert.Equal(r.Header, http.Header{HeaderContentType: []string{ContentTypeApplicationXML}})
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	assert.Nil(err)
+	assert.Equal(bodyBytes, []byte("<xmlBody><x>hello</x><y>goodbye</y></xmlBody>"))
+	assert.Equal(r.ContentLength, 0)
 }

--- a/webutil/webhook.go
+++ b/webutil/webhook.go
@@ -48,6 +48,7 @@ func (wh Webhook) Send() (*http.Response, error) {
 	req.Header = headers
 	if wh.Body != "" {
 		req.Body = ioutil.NopCloser(bytes.NewBufferString(wh.Body))
+		req.ContentLength = int64(len(wh.Body))
 	}
 
 	res, err := http.DefaultClient.Do(req)

--- a/webutil/webhook_test.go
+++ b/webutil/webhook_test.go
@@ -13,7 +13,7 @@ import (
 func TestWebhookSend(t *testing.T) {
 	assert := assert.New(t)
 
-	var bodyCorrect, methodCorrect, headerCorrect bool
+	var bodyCorrect, methodCorrect, headerCorrect, contentLengthCorrect bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -23,6 +23,7 @@ func TestWebhookSend(t *testing.T) {
 		bodyCorrect = string(body) == `this is only a test`
 		methodCorrect = r.Method == "POST"
 		headerCorrect = r.Header.Get("X-Test-Value") == "foo"
+		contentLengthCorrect = r.ContentLength == -1
 
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "OK!\n")
@@ -45,4 +46,5 @@ func TestWebhookSend(t *testing.T) {
 	assert.True(bodyCorrect)
 	assert.True(methodCorrect)
 	assert.True(headerCorrect)
+	assert.True(contentLengthCorrect)
 }

--- a/webutil/webhook_test.go
+++ b/webutil/webhook_test.go
@@ -23,7 +23,7 @@ func TestWebhookSend(t *testing.T) {
 		bodyCorrect = string(body) == `this is only a test`
 		methodCorrect = r.Method == "POST"
 		headerCorrect = r.Header.Get("X-Test-Value") == "foo"
-		contentLengthCorrect = r.ContentLength == -1
+		contentLengthCorrect = r.ContentLength == 19
 
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "OK!\n")


### PR DESCRIPTION
## PR Summary

This does not necessarily cover **all** cases where we set `req.Body`, but it covers most. This partially addresses #142, where we are sending chunked HTTP requests unwittingly.

 - **Type:** Bugfix
 - **Issue Link:** https://github.com/blend/go-sdk/issues/142
 - **Intended Change Level:** patch