### PR TITLE
Adding tests for `r2.OptLogResponse` and `OptLogResponseWithBody`.

### DIFF
--- a/r2/opt_log_response.go
+++ b/r2/opt_log_response.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OptLogResponse adds an OnResponse listener to log the response of a call.
-func OptLogResponse(log logger.Log) Option {
+func OptLogResponse(log logger.Triggerable) Option {
 	return OptOnResponse(func(req *http.Request, res *http.Response, started time.Time, err error) error {
 		if err != nil {
 			return err
@@ -30,7 +30,7 @@ func OptLogResponse(log logger.Log) Option {
 // OptLogResponseWithBody adds an OnResponse listener to log the response of a call.
 // It reads the contents of the response fully before emitting the event.
 // Do not use this if the size of the responses can be large.
-func OptLogResponseWithBody(log logger.Log) Option {
+func OptLogResponseWithBody(log logger.Triggerable) Option {
 	return OptOnResponse(func(req *http.Request, res *http.Response, started time.Time, err error) error {
 		if err != nil {
 			return err

--- a/r2/opt_log_response_test.go
+++ b/r2/opt_log_response_test.go
@@ -1,0 +1,81 @@
+package r2
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blend/go-sdk/assert"
+	"github.com/blend/go-sdk/logger"
+)
+
+// NOTE: Ensure that mockLogger satisfies the logger.Triggerable interface.
+var (
+	_ logger.Triggerable = (*mockLogger)(nil)
+)
+
+type mockLogger struct {
+	Events []logger.Event
+}
+
+func (ml *mockLogger) Trigger(ctx context.Context, e logger.Event) {
+	ml.Events = append(ml.Events, e)
+	return
+}
+
+func TestOptLogResponse(t *testing.T) {
+	assert := assert.New(t)
+	ml := &mockLogger{}
+	opt := OptLogResponse(ml)
+	e := logResponseHelper(assert, ml, opt, "OK!\n")
+	assert.Equal(e, Event{
+		Flag:     FlagResponse,
+		Request:  e.Request,
+		Response: e.Response,
+		Body:     nil,
+		Elapsed:  e.Elapsed,
+	})
+}
+
+func TestOptLogResponseWithBody(t *testing.T) {
+	assert := assert.New(t)
+	ml := &mockLogger{}
+	opt := OptLogResponseWithBody(ml)
+	body := "This is the response body\n"
+	e := logResponseHelper(assert, ml, opt, body)
+	assert.Equal(e, Event{
+		Flag:     FlagResponse,
+		Request:  e.Request,
+		Response: e.Response,
+		Body:     []byte(body),
+		Elapsed:  e.Elapsed,
+	})
+	assert.Equal(e.Request.ContentLength, 0)
+	assert.Equal(e.Response.ContentLength, 26)
+}
+
+func logResponseHelper(a *assert.Assertions, ml *mockLogger, opt Option, body string) Event {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, body)
+	}))
+	defer server.Close()
+
+	r := New(server.URL, opt)
+	res, err := r.Do()
+	a.Nil(err)
+	a.NotNil(res)
+	a.Equal(res.StatusCode, http.StatusOK)
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	a.Nil(err)
+	a.Equal(bodyBytes, []byte(body))
+
+	// Make sure the event was triggered.
+	a.Len(ml.Events, 1)
+	e, ok := ml.Events[0].(Event)
+	a.True(ok)
+	return e
+}


### PR DESCRIPTION
## PR Summary

In the process, limiting the interface to `logger.Triggerable` in the inputs. This came about when working on #148. I originally encountered this because I thought we needed [to set][1] `res.Body.ContentLength` but I later realized that response != request, so that change didn't belong in #148 (or anywhere).

 - **Type:** Internal
 - **Intended Change Level:** patch

[1]: https://github.com/blend/go-sdk/blob/f0e97061b7acb38342f100f234faa9a31b03b92a/r2/opt_log_response.go#L46