### PR TITLE
Fixing `started` -> `starting` copy-paste error.

### DIFF
--- a/async/latch.go
+++ b/async/latch.go
@@ -67,7 +67,7 @@ func (l *Latch) IsStopped() (isStopped bool) {
 	return atomic.LoadInt32(&l.state) == LatchStopped
 }
 
-// NotifyStarting returns the started signal.
+// NotifyStarting returns the starting signal.
 // It is used to coordinate the transition from stopped -> starting.
 func (l *Latch) NotifyStarting() (notifyStarting <-chan struct{}) {
 	l.Lock()


### PR DESCRIPTION
## PR Summary

 - **Type:** Documentation
 - **Intended Change Level:** patch