### PR TITLE
snapshot

### DIFF
--- a/webutil/cert_info_test.go
+++ b/webutil/cert_info_test.go
@@ -1,0 +1,50 @@
+package webutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestParseCertInfo(t *testing.T) {
+	assert := assert.New(t)
+
+	// handle the empty cases
+	assert.Nil(ParseCertInfo(nil))
+	assert.Nil(ParseCertInfo(&http.Response{}))
+	assert.Nil(ParseCertInfo(&http.Response{
+		TLS: &tls.ConnectionState{},
+	}))
+
+	valid := &http.Response{
+		TLS: &tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{
+				&x509.Certificate{
+					Issuer: pkix.Name{
+						CommonName: "bailey dog",
+					},
+					DNSNames:  []string{"foo.local"},
+					NotAfter:  time.Now().UTC().AddDate(0, 1, 0),
+					NotBefore: time.Now().UTC().AddDate(0, -1, 0),
+				},
+			},
+		},
+	}
+
+	info := ParseCertInfo(valid)
+	assert.NotNil(info)
+	assert.Equal("bailey dog", info.IssuerCommonName)
+	assert.Equal([]string{"foo.local"}, info.DNSNames)
+	assert.False(info.NotAfter.IsZero())
+	assert.False(info.NotBefore.IsZero())
+	assert.True(info.NotAfter.After(time.Now().UTC()))
+	assert.True(info.NotBefore.Before(time.Now().UTC()))
+
+	assert.False(info.IsExpired())
+	assert.False(info.WillBeExpired(time.Now().UTC()))
+}


### PR DESCRIPTION
## PR Summary

Adds method to detect a warning threshold on webutil.CertInfo, and adds tests.

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.