### PR TITLE
Fix job history leak

### DIFF
--- a/cron/constants.go
+++ b/cron/constants.go
@@ -18,8 +18,8 @@ const (
 	DefaultShouldSkipLoggerListeners = false
 	// DefaultShouldSkipLoggerOutput is a default.
 	DefaultShouldSkipLoggerOutput = false
-	// DefaultHistoryDisabled is a default.
-	DefaultHistoryDisabled = false
+	// DefaultHistoryEnabled is a default.
+	DefaultHistoryEnabled = false
 	// DefaultHistoryPersistenceEnabled is a default.
 	DefaultHistoryPersistenceEnabled = false
 	// DefaultHistoryMaxCount is the default number of history items to track.

--- a/cron/job_builder.go
+++ b/cron/job_builder.go
@@ -25,7 +25,7 @@ var (
 	_ OnFixedReceiver                   = (*JobBuilder)(nil)
 	_ OnEnabledReceiver                 = (*JobBuilder)(nil)
 	_ OnDisabledReceiver                = (*JobBuilder)(nil)
-	_ HistoryDisabledProvider           = (*JobBuilder)(nil)
+	_ HistoryEnabledProvider            = (*JobBuilder)(nil)
 	_ HistoryPersistenceEnabledProvider = (*JobBuilder)(nil)
 	_ HistoryMaxCountProvider           = (*JobBuilder)(nil)
 	_ HistoryMaxAgeProvider             = (*JobBuilder)(nil)
@@ -122,9 +122,9 @@ func OptJobOnDisabled(handler func(context.Context)) JobBuilderOption {
 	return func(jb *JobBuilder) { jb.OnDisabledHandler = handler }
 }
 
-// OptJobHistoryDisabled is a job builder option implementation.
-func OptJobHistoryDisabled(provider func() bool) JobBuilderOption {
-	return func(jb *JobBuilder) { jb.HistoryDisabledProvider = provider }
+// OptJobHistoryEnabled is a job builder option implementation.
+func OptJobHistoryEnabled(provider func() bool) JobBuilderOption {
+	return func(jb *JobBuilder) { jb.HistoryEnabledProvider = provider }
 }
 
 // OptJobHistoryPersistenceEnabled is a job builder option implementation.
@@ -154,7 +154,7 @@ type JobBuilder struct {
 	DisabledProvider                  func() bool
 	ShouldSkipLoggerListenersProvider func() bool
 	ShouldSkipLoggerOutputProvider    func() bool
-	HistoryDisabledProvider           func() bool
+	HistoryEnabledProvider            func() bool
 	HistoryMaxCountProvider           func() int
 	HistoryMaxAgeProvider             func() time.Duration
 	HistoryPersistenceEnabledProvider func() bool
@@ -237,12 +237,12 @@ func (jb *JobBuilder) ShouldSkipLoggerOutput() bool {
 	return jb.Config.ShouldSkipLoggerOutputOrDefault()
 }
 
-// HistoryDisabled implements the history disabled provider.
-func (jb *JobBuilder) HistoryDisabled() bool {
-	if jb.HistoryDisabledProvider != nil {
-		return jb.HistoryDisabledProvider()
+// HistoryEnabled implements the history disabled provider.
+func (jb *JobBuilder) HistoryEnabled() bool {
+	if jb.HistoryEnabledProvider != nil {
+		return jb.HistoryEnabledProvider()
 	}
-	return jb.Config.HistoryDisabledOrDefault()
+	return jb.Config.HistoryEnabledOrDefault()
 }
 
 // HistoryPersistenceEnabled implements the history enabled provider.

--- a/cron/job_config.go
+++ b/cron/job_config.go
@@ -21,9 +21,9 @@ type JobConfig struct {
 	// HistoryPersistenceEnabled determines if we should call the history persister if one is provided.
 	HistoryPersistenceEnabled *bool `json:"historyPersistenceEnabled" yaml:"historyPersistenceEnabled"`
 	// HistoryMaxCount is the maximum number of history items to keep.
-	HistoryMaxCount int `json:"historyMaxCount" yaml:"historyMaxCount"`
+	HistoryMaxCount *int `json:"historyMaxCount" yaml:"historyMaxCount"`
 	// HistoryMaxAge is the maximum age of history items to keep.
-	HistoryMaxAge time.Duration `json:"historyMaxAge" yaml:"historyMaxAge"`
+	HistoryMaxAge *time.Duration `json:"historyMaxAge" yaml:"historyMaxAge"`
 
 	// ShouldSkipLoggerListeners skips triggering logger events if it is set to true.
 	ShouldSkipLoggerListeners *bool `json:"shouldSkipLoggerListeners" yaml:"shouldSkipLoggerListeners"`
@@ -65,18 +65,18 @@ func (jc JobConfig) HistoryEnabledOrDefault() bool {
 
 // HistoryMaxCountOrDefault returns a value or a default.
 func (jc JobConfig) HistoryMaxCountOrDefault() int {
-	if jc.HistoryMaxCount > 0 {
-		return jc.HistoryMaxCount
+	if jc.HistoryMaxCount != nil {
+		return *jc.HistoryMaxCount
 	}
-	return 0
+	return DefaultHistoryMaxCount
 }
 
 // HistoryMaxAgeOrDefault returns a value or a default.
 func (jc JobConfig) HistoryMaxAgeOrDefault() time.Duration {
-	if jc.HistoryMaxAge > 0 {
-		return jc.HistoryMaxAge
+	if jc.HistoryMaxAge != nil {
+		return *jc.HistoryMaxAge
 	}
-	return 0
+	return DefaultHistoryMaxAge
 }
 
 // HistoryPersistenceEnabledOrDefault returns a value or a default.

--- a/cron/job_config.go
+++ b/cron/job_config.go
@@ -16,8 +16,8 @@ type JobConfig struct {
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 	// ShutdownGracePeriod represents the time a job is given to clean itself up.
 	ShutdownGracePeriod time.Duration `json:"shutdownGracePeriod" yaml:"shutdownGracePeriod"`
-	// HistoryDisabled sets if we should save invocation history and restore it.
-	HistoryDisabled *bool `json:"historyDisabled" yaml:"historyDisabled"`
+	// HistoryEnabled sets if we should save invocation history and restore it.
+	HistoryEnabled *bool `json:"historyEnabled" yaml:"historyEnabled"`
 	// HistoryPersistenceEnabled determines if we should call the history persister if one is provided.
 	HistoryPersistenceEnabled *bool `json:"historyPersistenceEnabled" yaml:"historyPersistenceEnabled"`
 	// HistoryMaxCount is the maximum number of history items to keep.
@@ -55,12 +55,12 @@ func (jc JobConfig) ShutdownGracePeriodOrDefault() time.Duration {
 	return DefaultShutdownGracePeriod
 }
 
-// HistoryDisabledOrDefault returns a value or a default.
-func (jc JobConfig) HistoryDisabledOrDefault() bool {
-	if jc.HistoryDisabled != nil {
-		return *jc.HistoryDisabled
+// HistoryEnabledOrDefault returns a value or a default.
+func (jc JobConfig) HistoryEnabledOrDefault() bool {
+	if jc.HistoryEnabled != nil {
+		return *jc.HistoryEnabled
 	}
-	return DefaultHistoryDisabled
+	return DefaultHistoryEnabled
 }
 
 // HistoryMaxCountOrDefault returns a value or a default.

--- a/cron/job_config_test.go
+++ b/cron/job_config_test.go
@@ -28,6 +28,6 @@ func TestJobConfig(t *testing.T) {
 	assert.Equal(jc.Timeout, jc.TimeoutOrDefault())
 	assert.Equal(jc.ShutdownGracePeriod, jc.ShutdownGracePeriodOrDefault())
 	assert.Equal(*jc.HistoryEnabled, jc.HistoryEnabledOrDefault())
-	assert.Equal(jc.HistoryMaxCount, jc.HistoryMaxCountOrDefault())
-	assert.Equal(jc.HistoryMaxAge, jc.HistoryMaxAgeOrDefault())
+	assert.Equal(*jc.HistoryMaxCount, jc.HistoryMaxCountOrDefault())
+	assert.Equal(*jc.HistoryMaxAge, jc.HistoryMaxAgeOrDefault())
 }

--- a/cron/job_config_test.go
+++ b/cron/job_config_test.go
@@ -15,19 +15,19 @@ func TestJobConfig(t *testing.T) {
 	var jc JobConfig
 	assert.Equal(DefaultTimeout, jc.TimeoutOrDefault())
 	assert.Equal(DefaultShutdownGracePeriod, jc.ShutdownGracePeriodOrDefault())
-	assert.Equal(DefaultHistoryDisabled, jc.HistoryDisabledOrDefault())
+	assert.Equal(DefaultHistoryEnabled, jc.HistoryEnabledOrDefault())
 	assert.Equal(0, jc.HistoryMaxCountOrDefault())
 	assert.Equal(0, jc.HistoryMaxAgeOrDefault())
 
 	jc.Timeout = time.Second
 	jc.ShutdownGracePeriod = time.Minute
-	jc.HistoryDisabled = ref.Bool(true)
+	jc.HistoryEnabled = ref.Bool(true)
 	jc.HistoryMaxCount = 5
 	jc.HistoryMaxAge = time.Hour
 
 	assert.Equal(jc.Timeout, jc.TimeoutOrDefault())
 	assert.Equal(jc.ShutdownGracePeriod, jc.ShutdownGracePeriodOrDefault())
-	assert.Equal(*jc.HistoryDisabled, jc.HistoryDisabledOrDefault())
+	assert.Equal(*jc.HistoryEnabled, jc.HistoryEnabledOrDefault())
 	assert.Equal(jc.HistoryMaxCount, jc.HistoryMaxCountOrDefault())
 	assert.Equal(jc.HistoryMaxAge, jc.HistoryMaxAgeOrDefault())
 }

--- a/cron/job_config_test.go
+++ b/cron/job_config_test.go
@@ -16,14 +16,14 @@ func TestJobConfig(t *testing.T) {
 	assert.Equal(DefaultTimeout, jc.TimeoutOrDefault())
 	assert.Equal(DefaultShutdownGracePeriod, jc.ShutdownGracePeriodOrDefault())
 	assert.Equal(DefaultHistoryEnabled, jc.HistoryEnabledOrDefault())
-	assert.Equal(0, jc.HistoryMaxCountOrDefault())
-	assert.Equal(0, jc.HistoryMaxAgeOrDefault())
+	assert.Equal(DefaultHistoryMaxCount, jc.HistoryMaxCountOrDefault())
+	assert.Equal(DefaultHistoryMaxAge, jc.HistoryMaxAgeOrDefault())
 
 	jc.Timeout = time.Second
 	jc.ShutdownGracePeriod = time.Minute
 	jc.HistoryEnabled = ref.Bool(true)
-	jc.HistoryMaxCount = 5
-	jc.HistoryMaxAge = time.Hour
+	jc.HistoryMaxCount = ref.Int(5)
+	jc.HistoryMaxAge = ref.Duration(time.Hour)
 
 	assert.Equal(jc.Timeout, jc.TimeoutOrDefault())
 	assert.Equal(jc.ShutdownGracePeriod, jc.ShutdownGracePeriodOrDefault())

--- a/cron/job_interfaces.go
+++ b/cron/job_interfaces.go
@@ -104,9 +104,9 @@ type OnEnabledReceiver interface {
 	OnEnabled(context.Context)
 }
 
-// HistoryDisabledProvider is an optional interface that will allow jobs to control if it should track history.
-type HistoryDisabledProvider interface {
-	HistoryDisabled() bool
+// HistoryEnabledProvider is an optional interface that will allow jobs to control if it should track history.
+type HistoryEnabledProvider interface {
+	HistoryEnabled() bool
 }
 
 // HistoryMaxCountProvider is an optional interface that will allow jobs to control how many history items are tracked.

--- a/cron/job_scheduler.go
+++ b/cron/job_scheduler.go
@@ -588,7 +588,7 @@ func (js *JobScheduler) finishCurrent(ji *JobInvocation) {
 	js.Lock()
 	defer js.Unlock()
 
-	if !js.HistoryEnabledProvider() {
+	if js.HistoryEnabledProvider() {
 		js.History = append(js.cullHistory(), *ji)
 	}
 	js.Current = nil

--- a/cron/job_scheduler.go
+++ b/cron/job_scheduler.go
@@ -59,10 +59,10 @@ func NewJobScheduler(job Job, options ...JobSchedulerOption) *JobScheduler {
 		js.DisabledProvider = func() bool { return js.Config.DisabledOrDefault() }
 	}
 
-	if typed, ok := job.(HistoryDisabledProvider); ok {
-		js.HistoryDisabledProvider = typed.HistoryDisabled
+	if typed, ok := job.(HistoryEnabledProvider); ok {
+		js.HistoryEnabledProvider = typed.HistoryEnabled
 	} else {
-		js.HistoryDisabledProvider = func() bool { return js.Config.HistoryDisabledOrDefault() }
+		js.HistoryEnabledProvider = func() bool { return js.Config.HistoryEnabledOrDefault() }
 	}
 
 	if typed, ok := job.(HistoryPersistenceEnabledProvider); ok {
@@ -131,7 +131,7 @@ type JobScheduler struct {
 	ShutdownGracePeriodProvider       func() time.Duration
 	ShouldSkipLoggerListenersProvider func() bool
 	ShouldSkipLoggerOutputProvider    func() bool
-	HistoryDisabledProvider           func() bool
+	HistoryEnabledProvider            func() bool
 	HistoryPersistenceEnabledProvider func() bool
 	HistoryMaxCountProvider           func() int
 	HistoryMaxAgeProvider             func() time.Duration
@@ -193,7 +193,7 @@ func (js *JobScheduler) Status() JobSchedulerStatus {
 		Current:                   js.Current,
 		Last:                      js.Last,
 		Stats:                     js.Stats(),
-		HistoryDisabled:           js.HistoryDisabledProvider(),
+		HistoryEnabled:            js.HistoryEnabledProvider(),
 		HistoryPersistenceEnabled: js.HistoryPersistenceEnabledProvider(),
 		HistoryMaxCount:           js.HistoryMaxCountProvider(),
 		HistoryMaxAge:             js.HistoryMaxAgeProvider(),
@@ -588,7 +588,7 @@ func (js *JobScheduler) finishCurrent(ji *JobInvocation) {
 	js.Lock()
 	defer js.Unlock()
 
-	if !js.HistoryDisabledProvider() {
+	if !js.HistoryEnabledProvider() {
 		js.History = append(js.cullHistory(), *ji)
 	}
 	js.Current = nil

--- a/cron/job_scheduler_status.go
+++ b/cron/job_scheduler_status.go
@@ -14,8 +14,8 @@ type JobSchedulerStatus struct {
 	Current                   *JobInvocation    `json:"current"`
 	Last                      *JobInvocation    `json:"last"`
 	Stats                     JobSchedulerStats `json:"stats"`
-	HistoryEnabled            bool              `json:"HistoryEnabled"`
-	HistoryPersistenceEnabled bool              `json:"HistoryPersistenceEnabled"`
+	HistoryEnabled            bool              `json:"historyEnabled"`
+	HistoryPersistenceEnabled bool              `json:"historyPersistenceEnabled"`
 	HistoryMaxCount           int               `json:"historyMaxCount"`
 	HistoryMaxAge             time.Duration     `json:"historyMaxAge"`
 }

--- a/cron/job_scheduler_status.go
+++ b/cron/job_scheduler_status.go
@@ -14,7 +14,7 @@ type JobSchedulerStatus struct {
 	Current                   *JobInvocation    `json:"current"`
 	Last                      *JobInvocation    `json:"last"`
 	Stats                     JobSchedulerStats `json:"stats"`
-	HistoryDisabled           bool              `json:"historyDisabled"`
+	HistoryEnabled            bool              `json:"HistoryEnabled"`
 	HistoryPersistenceEnabled bool              `json:"HistoryPersistenceEnabled"`
 	HistoryMaxCount           int               `json:"historyMaxCount"`
 	HistoryMaxAge             time.Duration     `json:"historyMaxAge"`

--- a/cron/job_scheduler_test.go
+++ b/cron/job_scheduler_test.go
@@ -118,7 +118,7 @@ func TestJobSchedulerPersistHistory(t *testing.T) {
 	js := NewJobScheduler(
 		NewJob(OptJobName("foo")),
 	)
-	js.HistoryDisabledProvider = func() bool { return false }
+	js.HistoryEnabledProvider = func() bool { return false }
 	js.HistoryPersistenceEnabledProvider = func() bool { return true }
 
 	assert.Nil(js.RestoreHistory(context.Background()))
@@ -134,7 +134,7 @@ func TestJobSchedulerPersistHistory(t *testing.T) {
 	js.Run()
 	assert.Len(<-history, 2)
 
-	js.HistoryDisabledProvider = func() bool { return true }
+	js.HistoryEnabledProvider = func() bool { return true }
 	js.Run()
 	assert.Len(<-history, 2)
 

--- a/cron/job_scheduler_test.go
+++ b/cron/job_scheduler_test.go
@@ -118,7 +118,7 @@ func TestJobSchedulerPersistHistory(t *testing.T) {
 	js := NewJobScheduler(
 		NewJob(OptJobName("foo")),
 	)
-	js.HistoryEnabledProvider = func() bool { return false }
+	js.HistoryEnabledProvider = func() bool { return true }
 	js.HistoryPersistenceEnabledProvider = func() bool { return true }
 
 	assert.Nil(js.RestoreHistory(context.Background()))
@@ -134,7 +134,7 @@ func TestJobSchedulerPersistHistory(t *testing.T) {
 	js.Run()
 	assert.Len(<-history, 2)
 
-	js.HistoryEnabledProvider = func() bool { return true }
+	js.HistoryEnabledProvider = func() bool { return false }
 	js.Run()
 	assert.Len(<-history, 2)
 


### PR DESCRIPTION
## PR Summary

The job history is enabled by default and the default max age and max count aren't set. This results in a default behavior of keeping the history of job invocations forever which results in a memory leak. This PR disables job history by default and provides default max age and max count when they're unset.

 - **Type:** Bugfix
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.