### PR TITLE
Making sure `web.Ctx.CookieDomain()` does not include port.

### DIFF
--- a/web/ctx.go
+++ b/web/ctx.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/blend/go-sdk/ex"
@@ -264,7 +265,9 @@ func (rc *Ctx) CookieDomain() string {
 		u := webutil.MustParseURL(rc.App.Config.BaseURL)
 		return u.Hostname()
 	}
-	return rc.Request.Host
+	// Strip off the port if the hostname includes it.
+	parts := strings.Split(rc.Request.Host, ":")
+	return parts[0]
 }
 
 // Cookie returns a named cookie from the request.

--- a/web/ctx.go
+++ b/web/ctx.go
@@ -261,7 +261,8 @@ func (rc *Ctx) PostBodyAsXML(response interface{}) error {
 // CookieDomain returns the cookie domain for a request.
 func (rc *Ctx) CookieDomain() string {
 	if rc.App != nil && rc.App.Config.BaseURL != "" {
-		return webutil.MustParseURL(rc.App.Config.BaseURL).Host
+		u := webutil.MustParseURL(rc.App.Config.BaseURL)
+		return u.Hostname()
 	}
 	return rc.Request.Host
 }

--- a/web/ctx_test.go
+++ b/web/ctx_test.go
@@ -159,7 +159,7 @@ func TestCtxWriteNewCookie(t *testing.T) {
 		HttpOnly: true,
 		Secure:   true,
 	})
-	assert.Equal("foo=bar; Path=/foo/bar; Domain=localhost; HttpOnly; Secure", context.Response.Header().Get("Set-Cookie"))
+	assert.Equal("foo=bar; Path=/foo/bar; HttpOnly; Secure", context.Response.Header().Get("Set-Cookie"))
 }
 
 func TestCtxExtendCookie(t *testing.T) {
@@ -184,4 +184,21 @@ func TestCtxExtendCookieByDuration(t *testing.T) {
 	assert.NotEmpty(cookies)
 	cookie := cookies[0]
 	assert.False(cookie.Expires.IsZero())
+}
+
+func TestCtxCookieDomain(t *testing.T) {
+	assert := assert.New(t)
+
+	// Fallback to `ctx.Request.Host`
+	ctx := MockCtx("GET", "/")
+	domain := ctx.CookieDomain()
+	assert.Equal("localhost:8080", domain)
+	assert.Nil(ctx.App)
+
+	// Use `ctx.App.Config.BaseURL`
+	cfg := Config{BaseURL: "http://localhost:8080"}
+	app := MustNew(OptConfig(cfg))
+	ctx = MockCtx("GET", "/", OptCtxApp(app))
+	domain = ctx.CookieDomain()
+	assert.Equal("localhost:8080", domain)
 }

--- a/web/ctx_test.go
+++ b/web/ctx_test.go
@@ -159,7 +159,7 @@ func TestCtxWriteNewCookie(t *testing.T) {
 		HttpOnly: true,
 		Secure:   true,
 	})
-	assert.Equal("foo=bar; Path=/foo/bar; HttpOnly; Secure", context.Response.Header().Get("Set-Cookie"))
+	assert.Equal("foo=bar; Path=/foo/bar; Domain=localhost; HttpOnly; Secure", context.Response.Header().Get("Set-Cookie"))
 }
 
 func TestCtxExtendCookie(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCtxCookieDomain(t *testing.T) {
 	// Fallback to `ctx.Request.Host`
 	ctx := MockCtx("GET", "/")
 	domain := ctx.CookieDomain()
-	assert.Equal("localhost:8080", domain)
+	assert.Equal("localhost", domain)
 	assert.Nil(ctx.App)
 
 	// Use `ctx.App.Config.BaseURL`

--- a/web/ctx_test.go
+++ b/web/ctx_test.go
@@ -200,5 +200,5 @@ func TestCtxCookieDomain(t *testing.T) {
 	app := MustNew(OptConfig(cfg))
 	ctx = MockCtx("GET", "/", OptCtxApp(app))
 	domain = ctx.CookieDomain()
-	assert.Equal("localhost:8080", domain)
+	assert.Equal("localhost", domain)
 }

--- a/webutil/mock_request.go
+++ b/webutil/mock_request.go
@@ -12,7 +12,7 @@ func NewMockRequest(method, path string) *http.Request {
 		Proto:      "http",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Host:       "localhost",
+		Host:       "localhost:8080",
 		RemoteAddr: "127.0.0.1:8080",
 		RequestURI: path,
 		Header: http.Header{

--- a/webutil/mock_request_test.go
+++ b/webutil/mock_request_test.go
@@ -11,7 +11,7 @@ func TestNewMockRequest(t *testing.T) {
 
 	req := NewMockRequest("OPTIONS", "/foo")
 	assert.Equal("OPTIONS", req.Method)
-	assert.Equal("localhost", req.Host)
+	assert.Equal("localhost:8080", req.Host)
 	assert.Equal("/foo", req.RequestURI)
 	assert.NotNil(req.URL)
 	assert.Equal("http", req.Proto)


### PR DESCRIPTION
## PR Summary

Fixes #156

 - **Type:** Bugfix
 - **Issue Link:** https://github.com/blend/go-sdk/issues/156
 - **Intended Change Level:** patch