### PR TITLE
Do not log broken pipe errors when rendering results

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -254,7 +254,7 @@ func (l *Logger) Close() error {
 	return nil
 }
 
-// Drain stops the evnet listeners, letting them complete their work
+// Drain stops the event listeners, letting them complete their work
 // and then restarts the listeners.
 func (l *Logger) Drain() error {
 	return l.DrainContext(context.Background())

--- a/web/app.go
+++ b/web/app.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/blend/go-sdk/async"
 	"github.com/blend/go-sdk/ex"
@@ -414,8 +415,8 @@ func (a *App) RenderAction(action Action) Handler {
 				}
 			}
 
-			// do the render, log any errors emitted
-			if resultErr := result.Render(ctx); resultErr != nil {
+			// do the render, log any errors emitted except broken pipe errors
+			if resultErr := result.Render(ctx); resultErr != nil && !ex.Is(resultErr, syscall.EPIPE) {
 				err = ex.Nest(err, resultErr)
 				a.maybeLogFatal(ctx.Context(), resultErr, ctx.Request)
 			}


### PR DESCRIPTION
## PR Summary

The web package is logging broken pipe errors as fatal errors which triggers an issue in sentry.  This PR skips logging for broken pipe errors returned after rendering a Result.  Tested this manually by running Deployinator locally and inducing broken pipe errors with and without this added check.

 - **Type:** Improvements
 - **Issue Link:** 
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.