### PR TITLE
Fix LRU Ordering & Sweep after Local Cache Updates

### DIFF
--- a/cache/local_cache.go
+++ b/cache/local_cache.go
@@ -131,8 +131,8 @@ func (lc *LocalCache) Set(key, value interface{}, options ...ValueOption) {
 		lc.Data = make(map[interface{}]*Value)
 	}
 	if value, ok := lc.Data[key]; ok {
-		*value = v
 		lc.LRU.Fix(&v)
+		*value = v
 	} else {
 		lc.Data[key] = &v
 		lc.LRU.Push(&v)
@@ -210,8 +210,8 @@ func (lc *LocalCache) GetOrSet(key interface{}, valueProvider func() (interface{
 
 	// upsert
 	if value, ok := lc.Data[key]; ok {
-		*value = v
 		lc.LRU.Fix(&v)
+		*value = v
 	} else {
 		lc.Data[key] = &v
 		lc.LRU.Push(&v)

--- a/cache/local_cache_test.go
+++ b/cache/local_cache_test.go
@@ -166,6 +166,27 @@ func TestLocalCacheGetOrSetDoubleCheckRace(t *testing.T) {
 	assert.Equal("bar2", found)
 }
 
+func TestLocalCacheSetUpdatesLRU(t *testing.T) {
+	assert := assert.New(t)
+
+	c := NewLocalCache()
+	c.Set("k1", "v1", OptValueTTL(0))
+	time.Sleep(time.Millisecond)
+	c.Set("k2", "v2", OptValueTTL(0))
+	assert.Equal("k1", c.LRU.Peek().Key)
+
+	// Should trigger sorting of underlying LRU so k2 can be
+	// deleted in next sweep
+	time.Sleep(time.Millisecond)
+	c.Set("k1", "v3", OptValueTTL(time.Second))
+
+	assert.Equal("k2", c.LRU.Peek().Key)
+
+	c.Sweep(context.Background())
+	assert.True(c.Has("k1"))
+	assert.False(c.Has("k2"))
+}
+
 func TestLocalCacheSweep(t *testing.T) {
 	assert := assert.New(t)
 

--- a/cache/local_cache_test.go
+++ b/cache/local_cache_test.go
@@ -171,13 +171,12 @@ func TestLocalCacheSetUpdatesLRU(t *testing.T) {
 
 	c := NewLocalCache()
 	c.Set("k1", "v1", OptValueTTL(0))
-	time.Sleep(time.Millisecond)
 	c.Set("k2", "v2", OptValueTTL(0))
 	assert.Equal("k1", c.LRU.Peek().Key)
 
+	time.Sleep(time.Millisecond)
 	// Should trigger sorting of underlying LRU so k2 can be
 	// deleted in next sweep
-	time.Sleep(time.Millisecond)
 	c.Set("k1", "v3", OptValueTTL(time.Second))
 	assert.Equal("k2", c.LRU.Peek().Key)
 

--- a/cache/local_cache_test.go
+++ b/cache/local_cache_test.go
@@ -179,7 +179,6 @@ func TestLocalCacheSetUpdatesLRU(t *testing.T) {
 	// deleted in next sweep
 	time.Sleep(time.Millisecond)
 	c.Set("k1", "v3", OptValueTTL(time.Second))
-
 	assert.Equal("k2", c.LRU.Peek().Key)
 
 	c.Sweep(context.Background())


### PR DESCRIPTION
## PR Summary

Holds off on updating value on reference shared by Cache's underlying map and LRU queue until after the LRU has processed the update.

 - **Type:** Bugfix
 - **Issue Link:** https://github.com/blend/go-sdk/issues/??
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.