### PR TITLE
Fixes `go-sdk/cron` handling of stateful schedules

### DIFF
--- a/cron/context.go
+++ b/cron/context.go
@@ -2,16 +2,9 @@ package cron
 
 import (
 	"context"
-
-	"github.com/blend/go-sdk/uuid"
 )
 
 type jobInvocationKey struct{}
-
-// NewJobInvocationID returns a new pseudo-unique job invocation identifier.
-func NewJobInvocationID() string {
-	return uuid.V4().String()
-}
 
 // WithJobInvocation adds a job invocation to a context as a value.
 func WithJobInvocation(ctx context.Context, ji *JobInvocation) context.Context {

--- a/cron/immediate_schedule.go
+++ b/cron/immediate_schedule.go
@@ -48,6 +48,7 @@ func (i *ImmediateSchedule) Next(after time.Time) time.Time {
 		i.didRun = true
 		return Now()
 	}
+
 	if i.then != nil {
 		return i.then.Next(after)
 	}

--- a/cron/immediate_schedule.go
+++ b/cron/immediate_schedule.go
@@ -2,7 +2,7 @@ package cron
 
 import (
 	"fmt"
-	"sync/atomic"
+	"sync"
 	"time"
 )
 
@@ -20,12 +20,13 @@ func Immediately() *ImmediateSchedule {
 
 // ImmediateSchedule fires immediately with an optional continuation schedule.
 type ImmediateSchedule struct {
-	didRun int32
+	sync.Mutex
+	didRun bool
 	then   Schedule
 }
 
 // String returns a string representation of the schedul.e
-func (i ImmediateSchedule) String() string {
+func (i *ImmediateSchedule) String() string {
 	if i.then != nil {
 		return fmt.Sprintf("immediately, then %v", i.then)
 	}
@@ -40,8 +41,11 @@ func (i *ImmediateSchedule) Then(then Schedule) Schedule {
 
 // Next implements Schedule.
 func (i *ImmediateSchedule) Next(after time.Time) time.Time {
-	if atomic.LoadInt32(&i.didRun) == 0 {
-		i.didRun = 1
+	i.Lock()
+	defer i.Unlock()
+
+	if !i.didRun {
+		i.didRun = true
 		return Now()
 	}
 	if i.then != nil {

--- a/cron/job_invocation.go
+++ b/cron/job_invocation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blend/go-sdk/bufferutil"
 	"github.com/blend/go-sdk/ex"
+	"github.com/blend/go-sdk/uuid"
 )
 
 // NewJobInvocation returns a new job invocation.
@@ -24,6 +25,11 @@ func NewJobInvocation(jobName string) *JobInvocation {
 		OutputHandlers: handlers,
 		Done:           make(chan struct{}),
 	}
+}
+
+// NewJobInvocationID returns a new pseudo-unique job invocation identifier.
+func NewJobInvocationID() string {
+	return uuid.V4().String()
 }
 
 // JobInvocation is metadata for a job invocation (or instance of a job running).

--- a/cron/job_scheduler_test.go
+++ b/cron/job_scheduler_test.go
@@ -21,8 +21,8 @@ func TestJobSchedulerCullHistoryMaxAge(t *testing.T) {
 	assert := assert.New(t)
 
 	js := NewJobScheduler(NewJob())
-	js.Config.HistoryMaxCount = ref.Int(10)
-	js.Config.HistoryMaxAge = ref.Duration(6 * time.Hour)
+	js.JobConfig.HistoryMaxCount = ref.Int(10)
+	js.JobConfig.HistoryMaxAge = ref.Duration(6 * time.Hour)
 
 	js.History = []JobInvocation{
 		{ID: uuid.V4().String(), Started: time.Now().Add(-10 * time.Hour)},
@@ -292,4 +292,8 @@ func TestSchedulerImediatelyThen(t *testing.T) {
 		assert.True(durations[x] < 2*time.Millisecond, durations[x].String())
 		assert.True(durations[x] > 500*time.Microsecond, durations[x].String())
 	}
+	assert.NotNil(js.JobSchedule)
+	typed, ok := js.JobSchedule.(*ImmediateSchedule)
+	assert.True(ok)
+	assert.True(typed.didRun)
 }

--- a/cron/job_scheduler_test.go
+++ b/cron/job_scheduler_test.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -258,4 +259,37 @@ func TestJobSchedulerJobParameters(t *testing.T) {
 	<-done
 	assert.Equal(testParameters, contextParameters)
 	assert.Equal(testParameters, invocationParameters)
+}
+
+func TestSchedulerImediatelyThen(t *testing.T) {
+	assert := assert.New(t)
+
+	wg := sync.WaitGroup{}
+	wg.Add(6)
+	var runCount int
+	var durations []time.Duration
+	last := time.Now().UTC()
+	job := NewJob(
+		OptJobSchedule(Immediately().Then(Times(5, Every(time.Millisecond)))),
+		OptJobAction(func(ctx context.Context) error {
+			defer wg.Done()
+			now := time.Now().UTC()
+			runCount++
+			durations = append(durations, now.Sub(last))
+			last = now
+			return nil
+		}),
+	)
+	js := NewJobScheduler(job)
+	go js.Start()
+	<-js.NotifyStarted()
+
+	wg.Wait()
+	assert.Equal(6, runCount)
+	assert.Len(durations, 6)
+	assert.True(durations[0] < time.Millisecond)
+	for x := 1; x < 6; x++ {
+		assert.True(durations[x] < 2*time.Millisecond, durations[x].String())
+		assert.True(durations[x] > 500*time.Microsecond, durations[x].String())
+	}
 }

--- a/cron/times_schedule.go
+++ b/cron/times_schedule.go
@@ -1,0 +1,53 @@
+package cron
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Interface assertions.
+var (
+	_ Schedule     = (*TimesSchedule)(nil)
+	_ fmt.Stringer = (*TimesSchedule)(nil)
+)
+
+// Times returns a new times schedule that returns a given
+// next run time from a schedule only a certain number of times.
+func Times(times int, schedule Schedule) *TimesSchedule {
+	return &TimesSchedule{
+		times:    times,
+		left:     times,
+		schedule: schedule,
+	}
+}
+
+// TimesSchedule is a schedule that only returns
+// a certain number of results.
+type TimesSchedule struct {
+	sync.Mutex
+
+	times    int
+	left     int
+	schedule Schedule
+}
+
+// Next implements cron.Schedule.
+func (ts *TimesSchedule) Next(after time.Time) time.Time {
+	ts.Lock()
+	defer ts.Unlock()
+
+	if ts.left > 0 {
+		ts.left = ts.left - 1
+		return ts.schedule.Next(after)
+	}
+	return Zero
+}
+
+// String returns a string representation of the schedul.e
+func (ts *TimesSchedule) String() string {
+	if typed, ok := ts.schedule.(fmt.Stringer); ok {
+		return fmt.Sprintf("%s %d/%d times", typed.String(), ts.left, ts.times)
+	}
+	return fmt.Sprintf("%d/%d times", ts.left, ts.times)
+}

--- a/cron/times_schedule_test.go
+++ b/cron/times_schedule_test.go
@@ -1,0 +1,21 @@
+package cron
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestTimesSchedule(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := time.Date(2020, 01, 23, 12, 11, 10, 9, time.UTC)
+	schedule := Times(5, Every(time.Millisecond))
+	assert.Equal(ts.Add(time.Millisecond), schedule.Next(ts))
+	assert.Equal(ts.Add(time.Millisecond), schedule.Next(ts))
+	assert.Equal(ts.Add(time.Millisecond), schedule.Next(ts))
+	assert.Equal(ts.Add(time.Millisecond), schedule.Next(ts))
+	assert.Equal(ts.Add(time.Millisecond), schedule.Next(ts))
+	assert.True(schedule.Next(ts).IsZero())
+}

--- a/examples/cron/immediate/main.go
+++ b/examples/cron/immediate/main.go
@@ -34,7 +34,7 @@ func NewConfigFromEnv() *Config {
 // InfrequentTask extends the lease on vault token.
 type InfrequentTask struct {
 	Config *Config
-	Log    *logger.Logger
+	Log    logger.Log
 }
 
 // Name returns the job name.

--- a/examples/cron/immediate/main.go
+++ b/examples/cron/immediate/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/blend/go-sdk/cron"
+	"github.com/blend/go-sdk/env"
+	"github.com/blend/go-sdk/graceful"
+	"github.com/blend/go-sdk/logger"
+)
+
+// NOTE: Ensure that
+//       * `InfrequentTask` satisfies `cron.Job`.
+//       * `InfrequentTask` satisfies `cron.ScheduleProvider`.
+var (
+	_ cron.Job              = (*InfrequentTask)(nil)
+	_ cron.ScheduleProvider = (*InfrequentTask)(nil)
+)
+
+// Config contains options for the command.
+type Config struct {
+	ServiceName string `json:"serviceName" yaml:"serviceName" env:"SERVICE_NAME"`
+	ServiceEnv  string `json:"serviceEnv" yaml:"serviceEnv" env:"SERVICE_ENV"`
+}
+
+// NewConfigFromEnv returns a new config from the environment.
+func NewConfigFromEnv() *Config {
+	var config Config
+	env.Env().ReadInto(&config)
+	return &config
+}
+
+// InfrequentTask extends the lease on vault token.
+type InfrequentTask struct {
+	Config *Config
+	Log    *logger.Logger
+}
+
+// Name returns the job name.
+func (it *InfrequentTask) Name() string {
+	return "infrequent_task"
+}
+
+// Schedule returns a schedule for the job.
+func (it *InfrequentTask) Schedule() cron.Schedule {
+	return cron.Immediately().Then(cron.EverySecond())
+}
+
+// Execute represents the job body.
+func (it *InfrequentTask) Execute(ctx context.Context) error {
+	sum := 0
+	for i := 0; i < 10000; i++ {
+		sum += i
+	}
+	logger.MaybeDebugf(it.Log, "Computed sum: %d", sum)
+	return nil
+}
+
+func main() {
+	log := logger.All()
+	config := NewConfigFromEnv()
+	log.Infof("starting `%s` infrequent task daemon", config.ServiceName)
+	jm := cron.Default()
+	cron.OptLog(log)(jm)
+	job := &InfrequentTask{Config: config, Log: log}
+	jm.LoadJobs(job)
+	if err := graceful.Shutdown(jm); err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Fixes an issue with a recent refactor of `go-sdk/cron` where we fetched the schedule off the job each execution, meaning that stateful schedules would always return the next run time based on their initial state.