### PR TITLE
Adds `r2.OptMaxRedirects` which overrides the default of 10

### DIFF
--- a/r2/opt_max_redirects.go
+++ b/r2/opt_max_redirects.go
@@ -11,9 +11,8 @@ import (
 
 // OptMaxRedirects tells the http client to only follow a given
 // number of redirects, overriding the standard library default of 10.
-// If a maximum number of redirects is reached, an exception of class `http.ErrUseLastResponse`
-// will be returned, with the redirect history as the exception message.
-// NOTE: that will make the exception message incredibly large.
+// Use the companion helper `ErrIsTooManyRedirects` to test if the returned error
+// from a call indicates the redirect limit was reached.
 func OptMaxRedirects(maxRedirects int) Option {
 	return func(r *Request) error {
 		if r.Client == nil {

--- a/r2/opt_max_redirects.go
+++ b/r2/opt_max_redirects.go
@@ -11,7 +11,7 @@ import (
 )
 
 // OptMaxRedirects tells the http client to only follow a given
-// set of redirects, overriding the standard library default of 10.
+// number of redirects, overriding the standard library default of 10.
 // If a maximum number of redirects is reached, an exception of class `http.ErrUseLastResponse`
 // will be returned, with the redirect history as the exception message.
 // NOTE: that will make the exception message incredibly large.

--- a/r2/opt_max_redirects.go
+++ b/r2/opt_max_redirects.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/blend/go-sdk/logger"
-
 	"github.com/blend/go-sdk/ex"
+	"github.com/blend/go-sdk/logger"
 )
 
 // OptMaxRedirects tells the http client to only follow a given

--- a/r2/opt_max_redirects.go
+++ b/r2/opt_max_redirects.go
@@ -1,0 +1,51 @@
+package r2
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/blend/go-sdk/logger"
+
+	"github.com/blend/go-sdk/ex"
+)
+
+// OptMaxRedirects tells the http client to only follow a given
+// set of redirects, overriding the standard library default of 10.
+// If a maximum number of redirects is reached, an exception of class `http.ErrUseLastResponse`
+// will be returned, with the redirect history as the exception message.
+// NOTE: that will make the exception message incredibly large.
+func OptMaxRedirects(maxRedirects int) Option {
+	return func(r *Request) error {
+		if r.Client == nil {
+			r.Client = &http.Client{}
+		}
+		r.Client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				r = r.WithContext(logger.WithAnnotations(r.Context(), logger.Annotations{
+					"via": urlStrings(via),
+				}))
+				return ex.New(http.ErrUseLastResponse)
+			}
+			return nil
+		}
+		return nil
+	}
+}
+
+// ErrIsTooManyRedirects returns if the error is too many redirects.
+func ErrIsTooManyRedirects(err error) bool {
+	if typed, ok := err.(*url.Error); ok {
+		return ex.Is(typed.Err, http.ErrUseLastResponse)
+	}
+	return false
+}
+
+func urlStrings(via []*http.Request) []string {
+	var output []string
+	for _, req := range via {
+		output = append(output, fmt.Sprintf("%s %v", strings.ToUpper(req.Method), req.URL.String()))
+	}
+	return output
+}

--- a/r2/opt_max_redirects.go
+++ b/r2/opt_max_redirects.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/blend/go-sdk/ex"
-	"github.com/blend/go-sdk/logger"
 )
 
 // OptMaxRedirects tells the http client to only follow a given
@@ -22,9 +21,6 @@ func OptMaxRedirects(maxRedirects int) Option {
 		}
 		r.Client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
 			if len(via) >= maxRedirects {
-				r = r.WithContext(logger.WithAnnotations(r.Context(), logger.Annotations{
-					"via": urlStrings(via),
-				}))
 				return ex.New(http.ErrUseLastResponse)
 			}
 			return nil

--- a/r2/opt_max_redirects_test.go
+++ b/r2/opt_max_redirects_test.go
@@ -1,0 +1,36 @@
+package r2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blend/go-sdk/assert"
+)
+
+func TestOptMaxRedirects(t *testing.T) {
+	assert := assert.New(t)
+
+	var pingURL, pongURL string
+	var pingCount, pongCount int
+	ping := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		pingCount++
+		http.Redirect(rw, r, pongURL, http.StatusTemporaryRedirect)
+		return
+	}))
+	defer ping.Close()
+
+	pong := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		pongCount++
+		http.Redirect(rw, r, pingURL, http.StatusTemporaryRedirect)
+		return
+	}))
+	defer pong.Close()
+
+	pingURL = ping.URL
+	pongURL = pong.URL
+
+	_, err := New(pingURL, OptMaxRedirects(32)).Discard()
+	assert.True(ErrIsTooManyRedirects(err))
+	assert.Equal(32, pingCount+pongCount)
+}


### PR DESCRIPTION
Adds an option to set the max redirects, but also adds a utility to check if the error returned on the request was the result of the maximum number of redirects being reached.