### PR TITLE
Add Flush to stats.Collector interface

### DIFF
--- a/stats/collector.go
+++ b/stats/collector.go
@@ -10,4 +10,5 @@ type Collector interface {
 	Gauge(name string, value float64, tags ...string) error
 	Histogram(name string, value float64, tags ...string) error
 	TimeInMilliseconds(name string, value time.Duration, tags ...string) error
+	Flush() error
 }

--- a/stats/mock_collector.go
+++ b/stats/mock_collector.go
@@ -15,8 +15,9 @@ var (
 // NewMockCollector returns a new mock collector.
 func NewMockCollector() *MockCollector {
 	return &MockCollector{
-		Events: make(chan MockMetric, 32),
-		Errors: make(chan error, 32),
+		Events:      make(chan MockMetric, 32),
+		Errors:      make(chan error, 32),
+		FlushErrors: make(chan error, 32),
 	}
 }
 
@@ -25,8 +26,9 @@ type MockCollector struct {
 	namespace   string
 	defaultTags []string
 
-	Events chan MockMetric
-	Errors chan error
+	Events      chan MockMetric
+	Errors      chan error
+	FlushErrors chan error
 }
 
 // AddDefaultTag adds a default tag.
@@ -86,8 +88,8 @@ func (mc MockCollector) TimeInMilliseconds(name string, value time.Duration, tag
 
 // Flush does nothing on a MockCollector.
 func (mc MockCollector) Flush() error {
-	if len(mc.Errors) > 0 {
-		return <-mc.Errors
+	if len(mc.FlushErrors) > 0 {
+		return <-mc.FlushErrors
 	}
 	return nil
 }

--- a/stats/mock_collector.go
+++ b/stats/mock_collector.go
@@ -84,6 +84,11 @@ func (mc MockCollector) TimeInMilliseconds(name string, value time.Duration, tag
 	return nil
 }
 
+// Flush does nothing on a MockCollector.
+func (mc MockCollector) Flush() error {
+	return nil
+}
+
 // MockMetric is a mock metric.
 type MockMetric struct {
 	Name               string

--- a/stats/mock_collector.go
+++ b/stats/mock_collector.go
@@ -86,6 +86,9 @@ func (mc MockCollector) TimeInMilliseconds(name string, value time.Duration, tag
 
 // Flush does nothing on a MockCollector.
 func (mc MockCollector) Flush() error {
+	if len(mc.Errors) > 0 {
+		return <-mc.Errors
+	}
 	return nil
 }
 

--- a/stats/mock_collector_test.go
+++ b/stats/mock_collector_test.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -120,4 +121,18 @@ func TestMockCollectorTimeInMilliseconds(t *testing.T) {
 	assert.Zero(mockMetric.Gauge)
 	assert.Zero(mockMetric.Count)
 	assert.Zero(mockMetric.Histogram)
+}
+
+func TestMockCollectorFlush(t *testing.T) {
+	assert := assert.New(t)
+
+	collector := NewMockCollector()
+
+	err := collector.Flush()
+	assert.Nil(err)
+
+	expectedErr := fmt.Errorf("err")
+	collector.Errors <- expectedErr
+	err = collector.Flush()
+	assert.Equal(expectedErr.Error(), err.Error())
 }

--- a/stats/mock_collector_test.go
+++ b/stats/mock_collector_test.go
@@ -132,7 +132,7 @@ func TestMockCollectorFlush(t *testing.T) {
 	assert.Nil(err)
 
 	expectedErr := fmt.Errorf("err")
-	collector.Errors <- expectedErr
+	collector.FlushErrors <- expectedErr
 	err = collector.Flush()
 	assert.Equal(expectedErr.Error(), err.Error())
 }

--- a/stats/multicollector.go
+++ b/stats/multicollector.go
@@ -85,3 +85,13 @@ func (collectors MultiCollector) TimeInMilliseconds(name string, value time.Dura
 	}
 	return nil
 }
+
+// Flush forces a flush on all collectors.
+func (collectors MultiCollector) Flush() error {
+	for _, collector := range collectors {
+		if err := collector.Flush(); err != nil {
+			return ex.New(err)
+		}
+	}
+	return nil
+}

--- a/stats/multicollector_test.go
+++ b/stats/multicollector_test.go
@@ -184,7 +184,7 @@ func TestFlush(t *testing.T) {
 	assert.Nil(err)
 
 	expectedError := fmt.Errorf("err")
-	c2.Errors <- expectedError
+	c2.FlushErrors <- expectedError
 	err = mc.Flush()
 	assert.Equal(expectedError.Error(), err.Error())
 }

--- a/stats/multicollector_test.go
+++ b/stats/multicollector_test.go
@@ -170,3 +170,21 @@ func TestTimeInMilliseconds(t *testing.T) {
 	assert.Zero(metric1.Histogram)
 	assert.Zero(metric1.Count)
 }
+
+func TestFlush(t *testing.T) {
+	assert := assert.New(t)
+
+	c1 := NewMockCollector()
+	c2 := NewMockCollector()
+
+	var err error
+	mc := MultiCollector{c1, c2}
+
+	err = mc.Flush()
+	assert.Nil(err)
+
+	expectedError := fmt.Errorf("err")
+	c2.Errors <- expectedError
+	err = mc.Flush()
+	assert.Equal(expectedError.Error(), err.Error())
+}


### PR DESCRIPTION
## PR Summary

This PR adds `Flush() error` to `stats.Collector` interface.

 - **Type:** Internal
 - **Issue Link:** N/A
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.