### PR TITLE
Add Close to stats.Collector interface

### DIFF
--- a/datadog/collector.go
+++ b/datadog/collector.go
@@ -102,6 +102,14 @@ func (dc *Collector) Flush() error {
 	return dc.client.Flush()
 }
 
+// Close closes the statsd client.
+func (dc *Collector) Close() error {
+	if dc.client == nil {
+		return nil
+	}
+	return dc.client.Close()
+}
+
 // SimpleEvent sends an event w/ title and text
 func (dc *Collector) SimpleEvent(title, text string) error {
 	return dc.client.SimpleEvent(title, text)

--- a/datadog/collector_test.go
+++ b/datadog/collector_test.go
@@ -55,6 +55,21 @@ func TestCollectorFlush(t *testing.T) {
 	assert.Nil(c.Flush())
 }
 
+func TestCollectorClose(t *testing.T) {
+	assert := assert.New(t)
+
+	// `client` is `nil`
+	c := Collector{}
+	assert.Nil(c.Close())
+
+	// `client` is not `nil`
+	client, err := statsd.New("localhost:8125")
+	assert.Nil(err)
+
+	c = Collector{client: client}
+	assert.Nil(c.Close())
+}
+
 func TestCollectorNew(t *testing.T) {
 	assert := assert.New(t)
 	cfg := Config{

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -11,4 +11,5 @@ type Collector interface {
 	Histogram(name string, value float64, tags ...string) error
 	TimeInMilliseconds(name string, value time.Duration, tags ...string) error
 	Flush() error
+	Close() error
 }

--- a/stats/mock_collector.go
+++ b/stats/mock_collector.go
@@ -18,6 +18,7 @@ func NewMockCollector() *MockCollector {
 		Events:      make(chan MockMetric, 32),
 		Errors:      make(chan error, 32),
 		FlushErrors: make(chan error, 32),
+		CloseErrors: make(chan error, 32),
 	}
 }
 
@@ -29,6 +30,7 @@ type MockCollector struct {
 	Events      chan MockMetric
 	Errors      chan error
 	FlushErrors chan error
+	CloseErrors chan error
 }
 
 // AddDefaultTag adds a default tag.
@@ -96,8 +98,8 @@ func (mc MockCollector) Flush() error {
 
 // Close returns an error from the errors channel if any.
 func (mc MockCollector) Close() error {
-	if len(mc.Errors) > 0 {
-		return <-mc.Errors
+	if len(mc.CloseErrors) > 0 {
+		return <-mc.CloseErrors
 	}
 	return nil
 }

--- a/stats/mock_collector.go
+++ b/stats/mock_collector.go
@@ -94,6 +94,14 @@ func (mc MockCollector) Flush() error {
 	return nil
 }
 
+// Close returns an error from the errors channel if any.
+func (mc MockCollector) Close() error {
+	if len(mc.Errors) > 0 {
+		return <-mc.Errors
+	}
+	return nil
+}
+
 // MockMetric is a mock metric.
 type MockMetric struct {
 	Name               string

--- a/stats/mock_collector_test.go
+++ b/stats/mock_collector_test.go
@@ -146,7 +146,7 @@ func TestMockCollectorClose(t *testing.T) {
 	assert.Nil(err)
 
 	expectedErr := fmt.Errorf("err")
-	collector.Errors <- expectedErr
+	collector.CloseErrors <- expectedErr
 	err = collector.Close()
 	assert.Equal(expectedErr.Error(), err.Error())
 }

--- a/stats/mock_collector_test.go
+++ b/stats/mock_collector_test.go
@@ -136,3 +136,17 @@ func TestMockCollectorFlush(t *testing.T) {
 	err = collector.Flush()
 	assert.Equal(expectedErr.Error(), err.Error())
 }
+
+func TestMockCollectorClose(t *testing.T) {
+	assert := assert.New(t)
+
+	collector := NewMockCollector()
+
+	err := collector.Close()
+	assert.Nil(err)
+
+	expectedErr := fmt.Errorf("err")
+	collector.Errors <- expectedErr
+	err = collector.Close()
+	assert.Equal(expectedErr.Error(), err.Error())
+}

--- a/stats/multicollector.go
+++ b/stats/multicollector.go
@@ -95,3 +95,13 @@ func (collectors MultiCollector) Flush() error {
 	}
 	return nil
 }
+
+// Close closes all collectors.
+func (collectors MultiCollector) Close() error {
+	for _, collector := range collectors {
+		if err := collector.Close(); err != nil {
+			return ex.New(err)
+		}
+	}
+	return nil
+}

--- a/stats/multicollector_test.go
+++ b/stats/multicollector_test.go
@@ -188,3 +188,21 @@ func TestFlush(t *testing.T) {
 	err = mc.Flush()
 	assert.Equal(expectedError.Error(), err.Error())
 }
+
+func TestClose(t *testing.T) {
+	assert := assert.New(t)
+
+	c1 := NewMockCollector()
+	c2 := NewMockCollector()
+
+	var err error
+	mc := MultiCollector{c1, c2}
+
+	err = mc.Close()
+	assert.Nil(err)
+
+	expectedError := fmt.Errorf("err")
+	c2.Errors <- expectedError
+	err = mc.Close()
+	assert.Equal(expectedError.Error(), err.Error())
+}

--- a/stats/multicollector_test.go
+++ b/stats/multicollector_test.go
@@ -202,7 +202,7 @@ func TestClose(t *testing.T) {
 	assert.Nil(err)
 
 	expectedError := fmt.Errorf("err")
-	c2.Errors <- expectedError
+	c2.CloseErrors <- expectedError
 	err = mc.Close()
 	assert.Equal(expectedError.Error(), err.Error())
 }


### PR DESCRIPTION
## PR Summary

This PR adds `Close() error` to `stats.Collector` interface.

 - **Type:** Features
 - **Issue Link:** N/A
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.