### PR TITLE
Adding `spiffeutil.ParseKubernetesWorkloadID()`.

### DIFF
--- a/spiffeutil/parse.go
+++ b/spiffeutil/parse.go
@@ -11,12 +11,21 @@ const (
 
 	// ErrInvalidURI is the class of error returned when parsing SPIFFE URI fails
 	ErrInvalidURI = ex.Class("Invalid SPIFFE URI")
+	// ErrNonKubernetesWorkload is class of error returned when parsing a SPIFFE
+	// Kubernetes workload identifier fails.
+	ErrNonKubernetesWorkload = ex.Class("Workload ID not in Kubernetes format")
 )
 
 // ParsedURI represents a SPIFFE URI that has been parsed via `Parse()`.
 type ParsedURI struct {
 	TrustDomain string
 	WorkloadID  string
+}
+
+// KubernetesWorkload describes a Kubernetes workload identifier.
+type KubernetesWorkload struct {
+	Namespace      string
+	ServiceAccount string
 }
 
 // Parse consumes a SPIFFE URI and splits out the trust domain and workload
@@ -36,4 +45,16 @@ func Parse(uri string) (*ParsedURI, error) {
 
 	pu := &ParsedURI{TrustDomain: parts[0], WorkloadID: parts[1]}
 	return pu, nil
+}
+
+// ParseKubernetesWorkloadID parses a SPIFFE workload identifier that identifies
+// Kubernetes service account, of the form  `ns/{namespace}/sa/{serviceAccount}`.
+func ParseKubernetesWorkloadID(workloadID string) (*KubernetesWorkload, error) {
+	parts := strings.Split(workloadID, "/")
+	if len(parts) != 4 || parts[0] != "ns" || parts[2] != "sa" {
+		err := ex.New(ErrNonKubernetesWorkload, ex.OptMessagef("Workload identifier: %q", workloadID))
+		return nil, err
+	}
+
+	return &KubernetesWorkload{Namespace: parts[1], ServiceAccount: parts[3]}, nil
 }


### PR DESCRIPTION
## PR Summary

 - **Type:** Features
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.