### PR TITLE
Don't shadow returned `err` in `certutil.ParseCertPEM()`.

### DIFF
--- a/certutil/pem_utils.go
+++ b/certutil/pem_utils.go
@@ -24,6 +24,7 @@ func CommonNamesForCertPEM(certPEM []byte) ([]string, error) {
 
 // ParseCertPEM parses the cert portion of a cert pair.
 func ParseCertPEM(certPem []byte) (output []*x509.Certificate, err error) {
+	var cert *x509.Certificate
 	for len(certPem) > 0 {
 		var block *pem.Block
 		block, certPem = pem.Decode(certPem)
@@ -34,7 +35,7 @@ func ParseCertPEM(certPem []byte) (output []*x509.Certificate, err error) {
 			continue
 		}
 
-		cert, err := x509.ParseCertificate(block.Bytes)
+		cert, err = x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			err = ex.New(err)
 			continue

--- a/certutil/pem_utils_test.go
+++ b/certutil/pem_utils_test.go
@@ -1,6 +1,7 @@
 package certutil
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/blend/go-sdk/assert"
@@ -13,6 +14,16 @@ func TestParseCertPEM(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(certs, 2)
 	assert.Equal(certLiteralCommonName, certs[0].Subject.CommonName)
+
+	invalidCert := []byte(strings.Join([]string{
+		"-----BEGIN CERTIFICATE-----",
+		"nope",
+		"-----END CERTIFICATE-----",
+		"",
+	}, "\n"))
+	certs, err = ParseCertPEM(invalidCert)
+	assert.Nil(certs)
+	assert.Nil(err)
 }
 
 func TestCommonNamesForCertPair(t *testing.T) {

--- a/certutil/pem_utils_test.go
+++ b/certutil/pem_utils_test.go
@@ -23,7 +23,7 @@ func TestParseCertPEM(t *testing.T) {
 	}, "\n"))
 	certs, err = ParseCertPEM(invalidCert)
 	assert.Nil(certs)
-	assert.Nil(err)
+	assert.Equal("asn1: syntax error: truncated tag or length", err.Error())
 }
 
 func TestCommonNamesForCertPair(t *testing.T) {


### PR DESCRIPTION
## PR Summary

 - **Type:** Bugfix
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.