### PR TITLE
Adding back support for remaining 5 XFCC fields.

### DIFF
--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -20,8 +20,9 @@ type XFCCElement struct {
 	// `url.URL` if desired.
 	By string
 	// Hash contains the SHA 256 digest of the current client certificate; this
-	// is a bytestring of 64 hexadecimal characters.
-	Hash []byte
+	// is a string of 64 hexadecimal characters. This can be converted to the raw
+	// bytes underlying the hex string via `hex.DecodeString(xe.Hash)`.
+	Hash string
 	// Cert contains the entire client certificate in URL encoded PEM format.
 	// It is present here as a `string` and can be parsed to an `x509.Certificate`
 	// if desired.
@@ -149,7 +150,10 @@ func fillXFCCKeyValue(key, element string, value []rune, ele *XFCCElement) (err 
 		}
 		ele.By = string(value)
 	case "hash":
-		return nil
+		if len(ele.Hash) > 0 {
+			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)
+		}
+		ele.Hash = string(value)
 	case "cert":
 		return nil
 	case "chain":

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -226,7 +226,7 @@ func fillXFCCKeyValue(key, element string, value []rune, ele *XFCCElement) (err 
 		}
 		ele.URI = string(value)
 	case "dns":
-		return nil
+		ele.DNS = append(ele.DNS, string(value))
 	default:
 		return ex.New(ErrXFCCParsing).WithMessagef("Unknown key %q", key)
 	}

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -1,6 +1,7 @@
 package envoyutil
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -21,7 +22,7 @@ type XFCCElement struct {
 	By string
 	// Hash contains the SHA 256 digest of the current client certificate; this
 	// is a string of 64 hexadecimal characters. This can be converted to the raw
-	// bytes underlying the hex string via `hex.DecodeString(xe.Hash)`.
+	// bytes underlying the hex string via `xe.DecodeHash()`.
 	Hash string
 	// Cert contains the entire client certificate in URL encoded PEM format.
 	// It is present here as a `string` and can be parsed to an `x509.Certificate`
@@ -40,6 +41,11 @@ type XFCCElement struct {
 	// certificate may contain multiple DNS SANs, each will be a separate
 	// key-value pair in the XFCC element.
 	DNS []string
+}
+
+// DecodeHash decodes the `Hash` element from a hex string to raw bytes.
+func (xe XFCCElement) DecodeHash() ([]byte, error) {
+	return hex.DecodeString(xe.Hash)
 }
 
 // maybeQuoted quotes a string value that may need to be quoted to be part of an

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -31,8 +31,8 @@ type XFCCElement struct {
 	// This can be decoded as a `*x509.Certificate` via `xe.DecodeCert()`.
 	Cert string
 	// Chain contains entire client certificate chain (including the leaf certificate)
-	// in URL encoded PEM format. It is present here as a `string` and can be parsed
-	// to a `[]x509.Certificate` if desired.
+	// in URL encoded PEM format. This can be decoded as a `[]*x509.Certificate` via
+	// `xe.DecodeChain()`.
 	Chain string
 	// Subject contains the `Subject` field of the current client certificate.
 	Subject string

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -78,6 +78,21 @@ func (xe XFCCElement) DecodeCert() (*x509.Certificate, error) {
 	return parsed[0], err
 }
 
+// DecodeChain decodes the `Chain` element from a URL encoded PEM to a
+// `[]x509.Certificate`.
+func (xe XFCCElement) DecodeChain() ([]*x509.Certificate, error) {
+	if xe.Chain == "" {
+		return nil, nil
+	}
+
+	value, err := url.QueryUnescape(xe.Chain)
+	if err != nil {
+		return nil, err
+	}
+
+	return certutil.ParseCertPEM([]byte(value))
+}
+
 // maybeQuoted quotes a string value that may need to be quoted to be part of an
 // XFCC header. It will use `%q` formatting to quote the value if it contains any
 // of `,` (comma), `;` (semi-colon), `=` (equals) or `"` (double quote).

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -216,7 +216,10 @@ func fillXFCCKeyValue(key, element string, value []rune, ele *XFCCElement) (err 
 		}
 		ele.Chain = string(value)
 	case "subject":
-		return nil
+		if len(ele.Subject) > 0 {
+			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)
+		}
+		ele.Subject = string(value)
 	case "uri":
 		if ele.URI != "" {
 			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -170,6 +170,10 @@ const (
 const (
 	// ErrXFCCParsing is the class of error returned when parsing XFCC fails
 	ErrXFCCParsing = ex.Class("Error Parsing X-Forwarded-Client-Cert")
+
+	// initialValueCapacity is the capacity used for a value in a key-value
+	// pair from an XFCC header.
+	initialValueCapacity = 8
 )
 
 type parseXFCCState int
@@ -199,7 +203,7 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 	state := parseXFCCKey
 	ele := XFCCElement{}
 	key := ""
-	value := []rune{}
+	value := make([]rune, 0, initialValueCapacity)
 	for _, char := range element {
 		switch state {
 		case parseXFCCKey:
@@ -219,7 +223,7 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 				}
 
 				key = ""
-				value = []rune{}
+				value = make([]rune, 0, initialValueCapacity)
 				state = parseXFCCKey
 			} else {
 				value = append(value, char)

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -155,7 +155,10 @@ func fillXFCCKeyValue(key, element string, value []rune, ele *XFCCElement) (err 
 		}
 		ele.Hash = string(value)
 	case "cert":
-		return nil
+		if len(ele.Cert) > 0 {
+			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)
+		}
+		ele.Cert = string(value)
 	case "chain":
 		return nil
 	case "subject":

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -148,8 +148,6 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 func fillXFCCKeyValue(key, element string, valueStart, valueEnd int, ele *XFCCElement) (err error) {
 	key = strings.ToLower(key)
 	switch key {
-	case "cert", "chain", "dns", "hash", "subject":
-		return nil
 	case "by":
 		if ele.By != "" {
 			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)
@@ -158,6 +156,14 @@ func fillXFCCKeyValue(key, element string, valueStart, valueEnd int, ele *XFCCEl
 		//       The assumption here is that the "valid range" invariant for these inputs is maintained
 		//       elsewhere, in `ParseXFCCElement()`.
 		ele.By = element[valueStart : valueEnd+1]
+	case "hash":
+		return nil
+	case "cert":
+		return nil
+	case "chain":
+		return nil
+	case "subject":
+		return nil
 	case "uri":
 		if ele.URI != "" {
 			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)
@@ -166,6 +172,8 @@ func fillXFCCKeyValue(key, element string, valueStart, valueEnd int, ele *XFCCEl
 		//       The assumption here is that the "valid range" invariant for these inputs is maintained
 		//       elsewhere, in `ParseXFCCElement()`.
 		ele.URI = element[valueStart : valueEnd+1]
+	case "dns":
+		return nil
 	default:
 		return ex.New(ErrXFCCParsing).WithMessagef("Unknown key %q", key)
 	}

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -14,12 +14,31 @@ import (
 type XFCC []XFCCElement
 
 // XFCCElement is an element in an XFCC header (see `XFCC`).
-//
-// NOTE: This is an intentionally limited coverage of the fields available in the XFCC
-//       header.
 type XFCCElement struct {
-	By  string
+	// By contains Subject Alternative Name (URI type) of the current proxy's
+	// certificate.	It is present here as a `string` and can be parsed to a
+	// `url.URL` if desired.
+	By string
+	// Hash contains the SHA 256 digest of the current client certificate; this
+	// is a bytestring of 64 hexadecimal characters.
+	Hash []byte
+	// Cert contains the entire client certificate in URL encoded PEM format.
+	// It is present here as a `string` and can be parsed to an `x509.Certificate`
+	// if desired.
+	Cert string
+	// Chain contains entire client certificate chain (including the leaf certificate)
+	// in URL encoded PEM format. It is present here as a `string` and can be parsed
+	// to a `[]x509.Certificate` if desired.
+	Chain string
+	// Subject contains the `Subject` field of the current client certificate.
+	Subject string
+	// URI contains the URI SAN of the current client certificate (assumes only
+	// one URI SAN).
 	URI string
+	// DNS contains the DNS SANs of the current client certificate. A client
+	// certificate may contain multiple DNS SANs, each will be a separate
+	// key-value pair in the XFCC element.
+	DNS []string
 }
 
 // maybeQuoted quotes a string value that may need to be quoted to be part of an

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -196,7 +196,10 @@ func fillXFCCKeyValue(key, element string, value []rune, ele *XFCCElement) (err 
 		}
 		ele.Cert = string(value)
 	case "chain":
-		return nil
+		if len(ele.Chain) > 0 {
+			return ex.New(ErrXFCCParsing).WithMessagef("Key already encountered %q", key)
+		}
+		ele.Chain = string(value)
 	case "subject":
 		return nil
 	case "uri":

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -46,12 +46,22 @@ type XFCCElement struct {
 
 // DecodeBy decodes the `By` element from a URI string to a `*url.URL`.
 func (xe XFCCElement) DecodeBy() (*url.URL, error) {
-	return url.Parse(xe.By)
+	u, err := url.Parse(xe.By)
+	if err != nil {
+		return nil, ex.New(err)
+	}
+
+	return u, nil
 }
 
 // DecodeHash decodes the `Hash` element from a hex string to raw bytes.
 func (xe XFCCElement) DecodeHash() ([]byte, error) {
-	return hex.DecodeString(xe.Hash)
+	bs, err := hex.DecodeString(xe.Hash)
+	if err != nil {
+		return nil, ex.New(err)
+	}
+
+	return bs, nil
 }
 
 // DecodeCert decodes the `Cert` element from a URL encoded PEM to a
@@ -63,12 +73,12 @@ func (xe XFCCElement) DecodeCert() (*x509.Certificate, error) {
 
 	value, err := url.QueryUnescape(xe.Cert)
 	if err != nil {
-		return nil, err
+		return nil, ex.New(err)
 	}
 
 	parsed, err := certutil.ParseCertPEM([]byte(value))
 	if err != nil {
-		return nil, err
+		return nil, ex.New(err)
 	}
 
 	if len(parsed) != 1 {
@@ -79,7 +89,7 @@ func (xe XFCCElement) DecodeCert() (*x509.Certificate, error) {
 		return nil, err
 	}
 
-	return parsed[0], err
+	return parsed[0], nil
 }
 
 // DecodeChain decodes the `Chain` element from a URL encoded PEM to a
@@ -91,15 +101,26 @@ func (xe XFCCElement) DecodeChain() ([]*x509.Certificate, error) {
 
 	value, err := url.QueryUnescape(xe.Chain)
 	if err != nil {
-		return nil, err
+		return nil, ex.New(err)
 	}
 
-	return certutil.ParseCertPEM([]byte(value))
+	parsed, err := certutil.ParseCertPEM([]byte(value))
+	if err != nil {
+		return nil, ex.New(err)
+	}
+
+	return parsed, nil
+
 }
 
 // DecodeURI decodes the `URI` element from a URI string to a `*url.URL`.
 func (xe XFCCElement) DecodeURI() (*url.URL, error) {
-	return url.Parse(xe.URI)
+	u, err := url.Parse(xe.URI)
+	if err != nil {
+		return nil, ex.New(err)
+	}
+
+	return u, nil
 }
 
 // maybeQuoted quotes a string value that may need to be quoted to be part of an

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -20,8 +20,7 @@ type XFCC []XFCCElement
 // XFCCElement is an element in an XFCC header (see `XFCC`).
 type XFCCElement struct {
 	// By contains Subject Alternative Name (URI type) of the current proxy's
-	// certificate.	It is present here as a `string` and can be parsed to a
-	// `url.URL` if desired.
+	// certificate.	This can be decoded as a `*url.URL` via `xe.DecodeBy()`.
 	By string
 	// Hash contains the SHA 256 digest of the current client certificate; this
 	// is a string of 64 hexadecimal characters. This can be converted to the raw
@@ -37,12 +36,17 @@ type XFCCElement struct {
 	// Subject contains the `Subject` field of the current client certificate.
 	Subject string
 	// URI contains the URI SAN of the current client certificate (assumes only
-	// one URI SAN).
+	// one URI SAN). This can be decoded as a `*url.URL` via `xe.DecodeURI()`.
 	URI string
 	// DNS contains the DNS SANs of the current client certificate. A client
 	// certificate may contain multiple DNS SANs, each will be a separate
 	// key-value pair in the XFCC element.
 	DNS []string
+}
+
+// DecodeBy decodes the `By` element from a URI string to a `*url.URL`.
+func (xe XFCCElement) DecodeBy() (*url.URL, error) {
+	return url.Parse(xe.By)
 }
 
 // DecodeHash decodes the `Hash` element from a hex string to raw bytes.
@@ -91,6 +95,11 @@ func (xe XFCCElement) DecodeChain() ([]*x509.Certificate, error) {
 	}
 
 	return certutil.ParseCertPEM([]byte(value))
+}
+
+// DecodeURI decodes the `URI` element from a URI string to a `*url.URL`.
+func (xe XFCCElement) DecodeURI() (*url.URL, error) {
+	return url.Parse(xe.URI)
 }
 
 // maybeQuoted quotes a string value that may need to be quoted to be part of an

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -119,9 +119,25 @@ func (xe XFCCElement) String() string {
 	if xe.By != "" {
 		parts = append(parts, fmt.Sprintf("By=%s", maybeQuoted(xe.By)))
 	}
+	if xe.Hash != "" {
+		parts = append(parts, fmt.Sprintf("Hash=%s", maybeQuoted(xe.Hash)))
+	}
+	if xe.Cert != "" {
+		parts = append(parts, fmt.Sprintf("Cert=%s", maybeQuoted(xe.Cert)))
+	}
+	if xe.Chain != "" {
+		parts = append(parts, fmt.Sprintf("Chain=%s", maybeQuoted(xe.Chain)))
+	}
+	if xe.Subject != "" {
+		parts = append(parts, fmt.Sprintf("Subject=%q", xe.Subject))
+	}
 	if xe.URI != "" {
 		parts = append(parts, fmt.Sprintf("URI=%s", maybeQuoted(xe.URI)))
 	}
+	for _, dnsSAN := range xe.DNS {
+		parts = append(parts, fmt.Sprintf("DNS=%s", maybeQuoted(dnsSAN)))
+	}
+
 	return strings.Join(parts, ";")
 }
 

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -112,6 +112,10 @@ func TestXFCCElementDecodeCert(t *testing.T) {
 			Cert:  url.QueryEscape(xfccElementTestCert + "\n" + xfccElementTestCert),
 			Error: "Error Parsing X-Forwarded-Client-Cert; Incorrect number of certificates; expected 1 got 2",
 		},
+		{
+			Cert:  xfccElementMultiCertTest,
+			Error: "Error Parsing X-Forwarded-Client-Cert; Incorrect number of certificates; expected 1 got 0",
+		},
 	}
 	for _, tc := range testCases {
 		xe := envoyutil.XFCCElement{Cert: tc.Cert}
@@ -276,7 +280,11 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementDNSTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{DNS: []string{"http://frontend.lyft.com"}}, ele)
+
+	ele, err = envoyutil.ParseXFCCElement("dns=web.invalid;dns=blend.local.invalid")
+	assert.Nil(err)
+	assert.Equal(envoyutil.XFCCElement{DNS: []string{"web.invalid", "blend.local.invalid"}}, ele)
 
 	_, err = envoyutil.ParseXFCCElement(xfccElementNoneTest)
 	assert.NotNil(err)
@@ -309,11 +317,7 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementEndTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
-
-	_, err = envoyutil.ParseXFCCElement(xfccElementMultiCertTest)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{DNS: []string{"http://frontend.lyft.com"}}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement("cert=" + xfccElementMalformedEncoding)
 	assert.Nil(err)

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -107,19 +107,30 @@ func TestParseXFCCElement(t *testing.T) {
 	assert.Equal(envoyutil.XFCCElement{Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688"}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementHashTest + ";" + xfccElementHashTest)
-	assert.NotNil(err)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
-	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
+	expectedErr := &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    `Key already encountered "hash"`,
+		StackTrace: except.StackTrace,
+	}
+	assert.Equal(expectedErr, except)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementCertTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{Cert: xfccElementTestCertEncoded}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementCertTest + ";" + xfccElementCertTest)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    `Key already encountered "cert"`,
+		StackTrace: except.StackTrace,
+	}
+	assert.Equal(expectedErr, except)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementChainTest)
 	assert.Nil(err)
@@ -192,7 +203,7 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement("cert=" + xfccElementMalformedEncoding)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{Cert: "%"}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement("chain=" + xfccElementMalformedEncoding)
 	assert.Nil(err)

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -109,7 +109,7 @@ func TestXFCCElementDecodeHash(t *testing.T) {
 	testCases := []testCase{
 		{Hash: "", Expected: []byte("")},
 		{Hash: "41434944", Expected: []byte("ACID")},
-		{Hash: "x", Expected: []byte(""), Error: "encoding/hex: invalid byte: U+0078 'x'"},
+		{Hash: "x", Expected: nil, Error: "encoding/hex: invalid byte: U+0078 'x'"},
 	}
 	for _, tc := range testCases {
 		xe := envoyutil.XFCCElement{Hash: tc.Hash}

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -199,11 +199,18 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementChainTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{Chain: xfccElementTestCertEncoded}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementChainTest + ";" + xfccElementChainTest)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    `Key already encountered "chain"`,
+		StackTrace: except.StackTrace,
+	}
+	assert.Equal(expectedErr, except)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementSubjectTest)
 	assert.Nil(err)
@@ -272,7 +279,7 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement("chain=" + xfccElementMalformedEncoding)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{Chain: "%"}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement("=;")
 	assert.NotNil(err)

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -60,6 +60,31 @@ JmUY+1YGMn7qbeHTma33N28Ec7hK+WByul746Nro
 -----END CERTIFICATE-----`
 )
 
+func TestXFCCElementDecodeHash(t *testing.T) {
+	assert := sdkAssert.New(t)
+
+	type testCase struct {
+		Hash     string
+		Expected []byte
+		Error    string
+	}
+	testCases := []testCase{
+		{Hash: "", Expected: []byte("")},
+		{Hash: "41434944", Expected: []byte("ACID")},
+		{Hash: "x", Expected: []byte(""), Error: "encoding/hex: invalid byte: U+0078 'x'"},
+	}
+	for _, tc := range testCases {
+		xe := envoyutil.XFCCElement{Hash: tc.Hash}
+		decoded, err := xe.DecodeHash()
+		assert.Equal(tc.Expected, decoded)
+		if tc.Error != "" {
+			assert.Equal(tc.Error, err.Error())
+		} else {
+			assert.Nil(err)
+		}
+	}
+}
+
 func TestXFCCElementString(t *testing.T) {
 	assert := sdkAssert.New(t)
 

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -104,11 +104,14 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementHashTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688"}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementHashTest + ";" + xfccElementHashTest)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.NotNil(err)
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementCertTest)
 	assert.Nil(err)
@@ -159,7 +162,11 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementMultiTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{By: "spiffe://cluster.local/ns/blend/sa/laser"}, ele)
+	expected := envoyutil.XFCCElement{
+		By:   "spiffe://cluster.local/ns/blend/sa/laser",
+		Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+	}
+	assert.Equal(expected, ele)
 
 	_, err = envoyutil.ParseXFCCElement(xfccElementMalformedKeyTest)
 	assert.NotNil(err)
@@ -202,7 +209,12 @@ func TestParseXFCCElement(t *testing.T) {
 	// Test empty subject
 	ele, err = envoyutil.ParseXFCCElement(`By=spiffe://cluster.local/ns/blend/sa/protocol;Hash=52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129;Subject="";URI=spiffe://cluster.local/ns/blend/sa/world`)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{By: "spiffe://cluster.local/ns/blend/sa/protocol", URI: "spiffe://cluster.local/ns/blend/sa/world"}, ele)
+	expected = envoyutil.XFCCElement{
+		By:   "spiffe://cluster.local/ns/blend/sa/protocol",
+		Hash: "52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129",
+		URI:  "spiffe://cluster.local/ns/blend/sa/world",
+	}
+	assert.Equal(expected, ele)
 }
 
 func TestParseXFCC(t *testing.T) {
@@ -211,8 +223,16 @@ func TestParseXFCC(t *testing.T) {
 	xfcc, err := envoyutil.ParseXFCC(fullXFCCTest + "," + fullXFCCTest)
 	assert.Nil(err)
 	expected := envoyutil.XFCC{
-		envoyutil.XFCCElement{By: "spiffe://cluster.local/ns/blend/sa/yule", URI: "spiffe://cluster.local/ns/blend/sa/cheer"},
-		envoyutil.XFCCElement{By: "spiffe://cluster.local/ns/blend/sa/yule", URI: "spiffe://cluster.local/ns/blend/sa/cheer"},
+		envoyutil.XFCCElement{
+			By:   "spiffe://cluster.local/ns/blend/sa/yule",
+			Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+			URI:  "spiffe://cluster.local/ns/blend/sa/cheer",
+		},
+		envoyutil.XFCCElement{
+			By:   "spiffe://cluster.local/ns/blend/sa/yule",
+			Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+			URI:  "spiffe://cluster.local/ns/blend/sa/cheer",
+		},
 	}
 	assert.Equal(expected, xfcc)
 

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -249,11 +249,18 @@ func TestParseXFCCElement(t *testing.T) {
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementSubjectTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCCElement{Subject: `"/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client"`}, ele)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementSubjectTest + ";" + xfccElementSubjectTest)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    `Key already encountered "subject"`,
+		StackTrace: except.StackTrace,
+	}
+	assert.Equal(expectedErr, except)
 
 	ele, err = envoyutil.ParseXFCCElement(xfccElementURITest)
 	assert.Nil(err)
@@ -328,9 +335,10 @@ func TestParseXFCCElement(t *testing.T) {
 	ele, err = envoyutil.ParseXFCCElement(`By=spiffe://cluster.local/ns/blend/sa/protocol;Hash=52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129;Subject="";URI=spiffe://cluster.local/ns/blend/sa/world`)
 	assert.Nil(err)
 	expected = envoyutil.XFCCElement{
-		By:   "spiffe://cluster.local/ns/blend/sa/protocol",
-		Hash: "52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129",
-		URI:  "spiffe://cluster.local/ns/blend/sa/world",
+		By:      "spiffe://cluster.local/ns/blend/sa/protocol",
+		Hash:    "52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129",
+		Subject: `""`,
+		URI:     "spiffe://cluster.local/ns/blend/sa/world",
 	}
 	assert.Equal(expected, ele)
 }
@@ -342,14 +350,16 @@ func TestParseXFCC(t *testing.T) {
 	assert.Nil(err)
 	expected := envoyutil.XFCC{
 		envoyutil.XFCCElement{
-			By:   "spiffe://cluster.local/ns/blend/sa/yule",
-			Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
-			URI:  "spiffe://cluster.local/ns/blend/sa/cheer",
+			By:      "spiffe://cluster.local/ns/blend/sa/yule",
+			Hash:    "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+			Subject: "/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client",
+			URI:     "spiffe://cluster.local/ns/blend/sa/cheer",
 		},
 		envoyutil.XFCCElement{
-			By:   "spiffe://cluster.local/ns/blend/sa/yule",
-			Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
-			URI:  "spiffe://cluster.local/ns/blend/sa/cheer",
+			By:      "spiffe://cluster.local/ns/blend/sa/yule",
+			Hash:    "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+			Subject: "/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client",
+			URI:     "spiffe://cluster.local/ns/blend/sa/cheer",
 		},
 	}
 	assert.Equal(expected, xfcc)

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -64,6 +64,38 @@ JmUY+1YGMn7qbeHTma33N28Ec7hK+WByul746Nro
 -----END CERTIFICATE-----`
 )
 
+func TestXFCCElementDecodeBy(t *testing.T) {
+	assert := sdkAssert.New(t)
+
+	type testCase struct {
+		By       string
+		Expected *url.URL
+		Error    string
+	}
+	testCases := []testCase{
+		{By: "", Expected: &url.URL{}},
+		{By: "\n", Error: `parse "\n": net/url: invalid control character in URL`},
+		{
+			By: "spiffe://cluster.local/ns/blend/sa/yule",
+			Expected: &url.URL{
+				Scheme: "spiffe",
+				Host:   "cluster.local",
+				Path:   "/ns/blend/sa/yule",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		xe := envoyutil.XFCCElement{By: tc.By}
+		uri, err := xe.DecodeBy()
+		assert.Equal(tc.Expected, uri)
+		if tc.Error != "" {
+			assert.Equal(tc.Error, err.Error())
+		} else {
+			assert.Nil(err)
+		}
+	}
+}
+
 func TestXFCCElementDecodeHash(t *testing.T) {
 	assert := sdkAssert.New(t)
 
@@ -161,6 +193,38 @@ func TestXFCCElementDecodeChain(t *testing.T) {
 			assert.Nil(err)
 		}
 		assert.Equal(tc.Parsed, chain)
+	}
+}
+
+func TestXFCCElementDecodeURI(t *testing.T) {
+	assert := sdkAssert.New(t)
+
+	type testCase struct {
+		URI      string
+		Expected *url.URL
+		Error    string
+	}
+	testCases := []testCase{
+		{URI: "", Expected: &url.URL{}},
+		{URI: "\r", Error: `parse "\r": net/url: invalid control character in URL`},
+		{
+			URI: "spiffe://cluster.local/ns/first/sa/furst",
+			Expected: &url.URL{
+				Scheme: "spiffe",
+				Host:   "cluster.local",
+				Path:   "/ns/first/sa/furst",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		xe := envoyutil.XFCCElement{URI: tc.URI}
+		uri, err := xe.DecodeURI()
+		assert.Equal(tc.Expected, uri)
+		if tc.Error != "" {
+			assert.Equal(tc.Error, err.Error())
+		} else {
+			assert.Nil(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## PR Summary

 - **Type:** Features
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.