### PR TITLE
Parsing XFCC header in a single pass.

### DIFF
--- a/envoyutil/identity_test.go
+++ b/envoyutil/identity_test.go
@@ -33,7 +33,7 @@ func TestExtractAndVerifyClientIdentity(t *testing.T) {
 	testCases := []testCase{
 		{ErrorType: "XFCCFatalError", Class: envoyutil.ErrMissingExtractFunction},
 		{XFCC: "", ErrorType: "XFCCExtractionError", Class: envoyutil.ErrMissingXFCC, Extract: extractJustURI},
-		{XFCC: `""`, ErrorType: "XFCCValidationError", Class: envoyutil.ErrInvalidXFCC, Extract: extractJustURI},
+		{XFCC: `""`, ErrorType: "XFCCExtractionError", Class: envoyutil.ErrInvalidXFCC, Extract: extractJustURI},
 		{XFCC: "something=bad", ErrorType: "XFCCExtractionError", Class: envoyutil.ErrInvalidXFCC, Extract: extractJustURI},
 		{
 			XFCC:      "By=first,URI=second",

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -189,8 +189,9 @@ const (
 
 // xfccParser holds state while an XFCC header is being parsed.
 type xfccParser struct {
+	Header  []rune
+	Index   int
 	State   parseXFCCState
-	Char    rune
 	Key     []rune
 	Value   []rune
 	Element XFCCElement
@@ -200,45 +201,46 @@ type xfccParser struct {
 // ParseXFCC parses the XFCC header.
 func ParseXFCC(header string) (XFCC, error) {
 	xp := &xfccParser{
-		Key:   make([]rune, 0, initialKeyCapacity),
-		Value: make([]rune, 0, initialValueCapacity),
-		State: parseXFCCKey,
+		Header: []rune(header),
+		Index:  0,
+		State:  parseXFCCKey,
+		Key:    make([]rune, 0, initialKeyCapacity),
+		Value:  make([]rune, 0, initialValueCapacity),
 	}
-	asRunes := []rune(header)
-	i := 0
-	for i < len(asRunes) {
-		xp.Char = asRunes[i]
+
+	for xp.Index < len(xp.Header) {
+		char := xp.Header[xp.Index]
 		switch xp.State {
 		case parseXFCCKey:
-			xp.HandleKeyCharacter()
+			xp.HandleKeyCharacter(char)
 		case parseXFCCValueStart:
-			xp.HandleValueStartCharacter()
+			xp.HandleValueStartCharacter(char)
 		case parseXFCCValue:
-			err := xp.HandleValueCharacter()
+			err := xp.HandleValueCharacter(char)
 			if err != nil {
 				return XFCC{}, err
 			}
 		case parseXFCCValueQuoted:
-			if xp.Char == '\\' {
-				nextIndex := i + 1
-				if nextIndex < len(asRunes) && asRunes[nextIndex] == '"' {
+			if char == '\\' {
+				nextIndex := xp.Index + 1
+				if nextIndex < len(xp.Header) && xp.Header[nextIndex] == '"' {
 					// Consume two characters at once here (since we have an
 					// escaped quote).
 					xp.Value = append(xp.Value, '"')
-					i = nextIndex
+					xp.Index = nextIndex
 				} else {
-					xp.Value = append(xp.Value, xp.Char)
+					xp.Value = append(xp.Value, char)
 				}
-			} else if xp.Char == '"' {
+			} else if char == '"' {
 				// Since the **escaped quote** case `\"` has already been
 				// covered, this case should only occur in the closing quote
 				// case.
-				nextIndex := i + 1
-				if nextIndex < len(asRunes) {
-					if asRunes[nextIndex] == ';' || asRunes[nextIndex] == ',' {
+				nextIndex := xp.Index + 1
+				if nextIndex < len(xp.Header) {
+					if xp.Header[nextIndex] == ';' || xp.Header[nextIndex] == ',' {
 						// Consume two characters at once here (since we have an
 						// closing quote).
-						i = nextIndex
+						xp.Index = nextIndex
 
 						if len(xp.Key) == 0 {
 							// Quoted values, e.g. `""`, are allowed to be empty.
@@ -252,7 +254,7 @@ func ParseXFCC(header string) (XFCC, error) {
 						xp.Key = make([]rune, 0, initialKeyCapacity)
 						xp.Value = make([]rune, 0, initialValueCapacity)
 						xp.State = parseXFCCKey
-						if asRunes[nextIndex] == ',' {
+						if xp.Header[nextIndex] == ',' {
 							xp.Parsed = append(xp.Parsed, xp.Element)
 							xp.Element = XFCCElement{}
 						}
@@ -260,18 +262,18 @@ func ParseXFCC(header string) (XFCC, error) {
 						return XFCC{}, ex.New(ErrXFCCParsing).WithMessage("Closing quote not followed by `;`.")
 					}
 				} else {
-					// NOTE: If `nextIndex >= len(asRunes)` then we are at the end,
+					// NOTE: If `nextIndex >= len(xp.Header)` then we are at the end,
 					//       which is a no-op here.
 					xp.State = parseXFCCKey
 				}
 			} else {
-				xp.Value = append(xp.Value, xp.Char)
+				xp.Value = append(xp.Value, char)
 			}
 		}
 
-		// Increment `i` for the next iteration. (Note that branches of the `switch`
-		// statement may have already incremented `i` as well.)
-		i++
+		// Increment the index for the next iteration. (Note that branches of the
+		// `switch` statement may have already incremented `i` as well.)
+		xp.Index++
 	}
 
 	if len(xp.Key) > 0 && len(xp.Value) > 0 {
@@ -337,29 +339,29 @@ func (xp *xfccParser) FillXFCCKeyValue() error {
 
 // HandleKeyCharacter advances the state machine if the current state is
 // `parseXFCCKey`.
-func (xp *xfccParser) HandleKeyCharacter() {
-	if xp.Char == '=' {
+func (xp *xfccParser) HandleKeyCharacter(char rune) {
+	if char == '=' {
 		xp.State = parseXFCCValueStart
 	} else {
-		xp.Key = append(xp.Key, xp.Char)
+		xp.Key = append(xp.Key, char)
 	}
 }
 
 // HandleValueStartCharacter advances the state machine if the current state is
 // `parseXFCCValueStart`.
-func (xp *xfccParser) HandleValueStartCharacter() {
-	if xp.Char == '"' {
+func (xp *xfccParser) HandleValueStartCharacter(char rune) {
+	if char == '"' {
 		xp.State = parseXFCCValueQuoted
 	} else {
-		xp.Value = append(xp.Value, xp.Char)
+		xp.Value = append(xp.Value, char)
 		xp.State = parseXFCCValue
 	}
 }
 
 // HandleValueCharacter advances the state machine if the current state is
 // `parseXFCCValue`.
-func (xp *xfccParser) HandleValueCharacter() error {
-	if xp.Char == ',' || xp.Char == ';' {
+func (xp *xfccParser) HandleValueCharacter(char rune) error {
+	if char == ',' || char == ';' {
 		if len(xp.Key) == 0 || len(xp.Value) == 0 {
 			return ex.New(ErrXFCCParsing).WithMessage("Key or Value missing")
 		}
@@ -371,12 +373,12 @@ func (xp *xfccParser) HandleValueCharacter() error {
 		xp.Key = make([]rune, 0, initialKeyCapacity)
 		xp.Value = make([]rune, 0, initialValueCapacity)
 		xp.State = parseXFCCKey
-		if xp.Char == ',' {
+		if char == ',' {
 			xp.Parsed = append(xp.Parsed, xp.Element)
 			xp.Element = XFCCElement{}
 		}
 	} else {
-		xp.Value = append(xp.Value, xp.Char)
+		xp.Value = append(xp.Value, char)
 	}
 
 	return nil

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -211,18 +211,9 @@ func ParseXFCC(header string) (XFCC, error) {
 		xp.Char = asRunes[i]
 		switch xp.State {
 		case parseXFCCKey:
-			if xp.Char == '=' {
-				xp.State = parseXFCCValueStart
-			} else {
-				xp.Key = append(xp.Key, xp.Char)
-			}
+			xp.HandleKeyCharacter()
 		case parseXFCCValueStart:
-			if xp.Char == '"' {
-				xp.State = parseXFCCValueQuoted
-			} else {
-				xp.Value = append(xp.Value, xp.Char)
-				xp.State = parseXFCCValue
-			}
+			xp.HandleValueStartCharacter()
 		case parseXFCCValue:
 			if xp.Char == ',' || xp.Char == ';' {
 				if len(xp.Key) == 0 || len(xp.Value) == 0 {
@@ -358,4 +349,25 @@ func (xp *xfccParser) FillXFCCKeyValue() error {
 	}
 
 	return nil
+}
+
+// HandleKeyCharacter advances the state machine if the current state is
+// `parseXFCCKey`.
+func (xp *xfccParser) HandleKeyCharacter() {
+	if xp.Char == '=' {
+		xp.State = parseXFCCValueStart
+	} else {
+		xp.Key = append(xp.Key, xp.Char)
+	}
+}
+
+// HandleValueStartCharacter advances the state machine if the current state is
+// `parseXFCCValueStart`.
+func (xp *xfccParser) HandleValueStartCharacter() {
+	if xp.Char == '"' {
+		xp.State = parseXFCCValueQuoted
+	} else {
+		xp.Value = append(xp.Value, xp.Char)
+		xp.State = parseXFCCValue
+	}
 }

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -47,7 +47,7 @@ type XFCCElement struct {
 func (xe XFCCElement) DecodeBy() (*url.URL, error) {
 	u, err := url.Parse(xe.By)
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	return u, nil
@@ -57,7 +57,7 @@ func (xe XFCCElement) DecodeBy() (*url.URL, error) {
 func (xe XFCCElement) DecodeHash() ([]byte, error) {
 	bs, err := hex.DecodeString(xe.Hash)
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	return bs, nil
@@ -72,12 +72,12 @@ func (xe XFCCElement) DecodeCert() (*x509.Certificate, error) {
 
 	value, err := url.QueryUnescape(xe.Cert)
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	parsed, err := certutil.ParseCertPEM([]byte(value))
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	if len(parsed) != 1 {
@@ -100,12 +100,12 @@ func (xe XFCCElement) DecodeChain() ([]*x509.Certificate, error) {
 
 	value, err := url.QueryUnescape(xe.Chain)
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	parsed, err := certutil.ParseCertPEM([]byte(value))
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	return parsed, nil
@@ -116,7 +116,7 @@ func (xe XFCCElement) DecodeChain() ([]*x509.Certificate, error) {
 func (xe XFCCElement) DecodeURI() (*url.URL, error) {
 	u, err := url.Parse(xe.URI)
 	if err != nil {
-		return nil, ex.New(err)
+		return nil, ex.New(ErrXFCCParsing).WithInner(err)
 	}
 
 	return u, nil

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -303,20 +303,6 @@ func ParseXFCC(header string) (XFCC, error) {
 	return xfcc, nil
 }
 
-// ParseXFCCElement is a legacy stub (intact now just to avoid rewriting too
-// many tests).
-func ParseXFCCElement(element string) (XFCCElement, error) {
-	xfcc, err := ParseXFCC(element)
-	if err != nil {
-		return XFCCElement{}, err
-	}
-	if len(xfcc) != 1 {
-		return XFCCElement{}, ex.New(ErrXFCCParsing).WithMessage("WRENCH")
-	}
-
-	return xfcc[0], nil
-}
-
 func fillXFCCKeyValue(key string, value []rune, ele *XFCCElement) (err error) {
 	key = strings.ToLower(key)
 	switch key {

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -200,12 +200,20 @@ type xfccParser struct {
 
 // ParseXFCC parses the XFCC header.
 func ParseXFCC(header string) (XFCC, error) {
+	if header == "" {
+		return XFCC{}, nil
+	}
+
 	xp := &xfccParser{
 		Header: []rune(header),
 		Index:  0,
 		State:  parseXFCCKey,
 		Key:    make([]rune, 0, initialKeyCapacity),
 		Value:  make([]rune, 0, initialValueCapacity),
+	}
+	lastCharacter := xp.Header[len(xp.Header)-1]
+	if lastCharacter == ',' || lastCharacter == ';' {
+		return XFCC{}, ex.New(ErrXFCCParsing).WithMessage("Ends with separator character")
 	}
 
 	for xp.Index < len(xp.Header) {

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -248,9 +248,9 @@ func ParseXFCC(header string) (XFCC, error) {
 	return xp.Parsed, nil
 }
 
-// FillXFCCKeyValue takes the currently active `.Key` and `.Value` and populates
+// FillKeyValue takes the currently active `.Key` and `.Value` and populates
 // the current `.Element`.
-func (xp *xfccParser) FillXFCCKeyValue() error {
+func (xp *xfccParser) FillKeyValue() error {
 	keyLower := strings.ToLower(string(xp.Key))
 	switch keyLower {
 	case "by":
@@ -320,7 +320,7 @@ func (xp *xfccParser) HandleValueCharacter(char rune) error {
 		if len(xp.Key) == 0 || len(xp.Value) == 0 {
 			return ex.New(ErrXFCCParsing).WithMessage("Key or Value missing")
 		}
-		err := xp.FillXFCCKeyValue()
+		err := xp.FillKeyValue()
 		if err != nil {
 			return err
 		}
@@ -367,7 +367,7 @@ func (xp *xfccParser) HandleQuotedValueCharacter(char rune) error {
 					// Quoted values, e.g. `""`, are allowed to be empty.
 					return ex.New(ErrXFCCParsing).WithMessage("Key missing")
 				}
-				err := xp.FillXFCCKeyValue()
+				err := xp.FillKeyValue()
 				if err != nil {
 					return err
 				}
@@ -399,7 +399,7 @@ func (xp *xfccParser) HandleQuotedValueCharacter(char rune) error {
 // if need be.
 func (xp *xfccParser) Finalize() error {
 	if len(xp.Key) > 0 && len(xp.Value) > 0 {
-		err := xp.FillXFCCKeyValue()
+		err := xp.FillKeyValue()
 		if err != nil {
 			return err
 		}

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -228,7 +228,7 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 				if len(key) == 0 || len(value) == 0 {
 					return XFCCElement{}, ex.New(ErrXFCCParsing).WithMessage("Key or Value missing")
 				}
-				err := fillXFCCKeyValue(key, element, value, &ele)
+				err := fillXFCCKeyValue(key, value, &ele)
 				if err != nil {
 					return XFCCElement{}, err
 				}
@@ -268,7 +268,7 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 						// Quoted values, e.g. `""`, are allowed to be empty.
 						return XFCCElement{}, ex.New(ErrXFCCParsing).WithMessage("Key missing")
 					}
-					err := fillXFCCKeyValue(key, element, value, &ele)
+					err := fillXFCCKeyValue(key, value, &ele)
 					if err != nil {
 						return XFCCElement{}, err
 					}
@@ -292,7 +292,7 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 	}
 
 	if len(key) > 0 && len(value) > 0 {
-		return ele, fillXFCCKeyValue(key, element, value, &ele)
+		return ele, fillXFCCKeyValue(key, value, &ele)
 	}
 
 	if len(key) > 0 || len(value) > 0 {
@@ -302,7 +302,7 @@ func ParseXFCCElement(element string) (XFCCElement, error) {
 	return ele, nil
 }
 
-func fillXFCCKeyValue(key, element string, value []rune, ele *XFCCElement) (err error) {
+func fillXFCCKeyValue(key string, value []rune, ele *XFCCElement) (err error) {
 	key = strings.ToLower(key)
 	switch key {
 	case "by":

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -194,12 +194,11 @@ type xfccParser struct {
 	Key     []rune
 	Value   []rune
 	Element XFCCElement
+	Parsed  XFCC
 }
 
 // ParseXFCC parses the XFCC header.
 func ParseXFCC(header string) (XFCC, error) {
-	xfcc := XFCC{}
-
 	xp := &xfccParser{
 		Key: make([]rune, 0, initialKeyCapacity),
 		Value: make([]rune, 0, initialValueCapacity),
@@ -228,7 +227,7 @@ func ParseXFCC(header string) (XFCC, error) {
 				xp.Value = make([]rune, 0, initialValueCapacity)
 				xp.State = parseXFCCKey
 				if xp.Char == ',' {
-					xfcc = append(xfcc, xp.Element)
+					xp.Parsed = append(xp.Parsed, xp.Element)
 					xp.Element = XFCCElement{}
 				}
 			} else {
@@ -269,7 +268,7 @@ func ParseXFCC(header string) (XFCC, error) {
 						xp.Value = make([]rune, 0, initialValueCapacity)
 						xp.State = parseXFCCKey
 						if asRunes[nextIndex] == ',' {
-							xfcc = append(xfcc, xp.Element)
+							xp.Parsed = append(xp.Parsed, xp.Element)
 							xp.Element = XFCCElement{}
 						}
 					} else {
@@ -295,16 +294,16 @@ func ParseXFCC(header string) (XFCC, error) {
 		if err != nil {
 			return XFCC{}, err
 		}
-		xfcc = append(xfcc, xp.Element)
-		return xfcc, nil
+		xp.Parsed = append(xp.Parsed, xp.Element)
+		return xp.Parsed, nil
 	}
 
 	if len(xp.Key) > 0 || len(xp.Value) > 0 {
 		return XFCC{}, ex.New(ErrXFCCParsing).WithMessage("Key or value found but not both")
 	}
 
-	xfcc = append(xfcc, xp.Element)
-	return xfcc, nil
+	xp.Parsed = append(xp.Parsed, xp.Element)
+	return xp.Parsed, nil
 }
 
 // FillXFCCKeyValue takes the currently active `.Key` and `.Value` and populates

--- a/envoyutil/xfcc.go
+++ b/envoyutil/xfcc.go
@@ -227,7 +227,7 @@ func ParseXFCC(header string) (XFCC, error) {
 				if len(xp.Key) == 0 || len(xp.Value) == 0 {
 					return XFCC{}, ex.New(ErrXFCCParsing).WithMessage("Key or Value missing")
 				}
-				err := fillXFCCKeyValue(xp)
+				err := xp.FillXFCCKeyValue()
 				if err != nil {
 					return XFCC{}, err
 				}
@@ -268,7 +268,7 @@ func ParseXFCC(header string) (XFCC, error) {
 							// Quoted values, e.g. `""`, are allowed to be empty.
 							return XFCC{}, ex.New(ErrXFCCParsing).WithMessage("Key missing")
 						}
-						err := fillXFCCKeyValue(xp)
+						err := xp.FillXFCCKeyValue()
 						if err != nil {
 							return XFCC{}, err
 						}
@@ -299,7 +299,7 @@ func ParseXFCC(header string) (XFCC, error) {
 	}
 
 	if len(xp.Key) > 0 && len(xp.Value) > 0 {
-		err := fillXFCCKeyValue(xp)
+		err := xp.FillXFCCKeyValue()
 		if err != nil {
 			return XFCC{}, err
 		}
@@ -315,7 +315,9 @@ func ParseXFCC(header string) (XFCC, error) {
 	return xfcc, nil
 }
 
-func fillXFCCKeyValue(xp *xfccParser) (err error) {
+// FillXFCCKeyValue takes the currently active `.Key` and `.Value` and populates
+// the current `.Element`.
+func (xp *xfccParser) FillXFCCKeyValue() error {
 	keyLower := strings.ToLower(string(xp.Key))
 	switch keyLower {
 	case "by":
@@ -353,5 +355,6 @@ func fillXFCCKeyValue(xp *xfccParser) (err error) {
 	default:
 		return ex.New(ErrXFCCParsing).WithMessagef("Unknown key %q", keyLower)
 	}
+
 	return nil
 }

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -585,4 +585,21 @@ func TestParseXFCC(t *testing.T) {
 		envoyutil.XFCCElement{URI: "you"},
 	}
 	assert.Equal(expected, xfcc)
+
+	// KV separator is the last character
+	xfcc, err = envoyutil.ParseXFCC("by=cliffhanger;")
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{By: "cliffhanger"},
+	}
+	assert.Equal(expected, xfcc)
+
+	// Element separator is the last character
+	xfcc, err = envoyutil.ParseXFCC("uri=cliffhanger,")
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{URI: "cliffhanger"},
+		envoyutil.XFCCElement{},
+	}
+	assert.Equal(expected, xfcc)
 }

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -235,47 +235,50 @@ func TestXFCCElementString(t *testing.T) {
 	assert := sdkAssert.New(t)
 
 	type testCase struct {
-		Element  *envoyutil.XFCCElement
+		Element  envoyutil.XFCCElement
 		Expected string
 	}
 	testCases := []testCase{
-		{Element: &envoyutil.XFCCElement{}, Expected: ""},
-		{Element: &envoyutil.XFCCElement{By: "hi"}, Expected: "By=hi"},
-		{Element: &envoyutil.XFCCElement{Hash: "1389ab1"}, Expected: "Hash=1389ab1"},
-		{Element: &envoyutil.XFCCElement{Cert: "anything-goes"}, Expected: "Cert=anything-goes"},
-		{Element: &envoyutil.XFCCElement{Chain: "anything-goes"}, Expected: "Chain=anything-goes"},
+		{Element: envoyutil.XFCCElement{}, Expected: ""},
+		{Element: envoyutil.XFCCElement{By: "hi"}, Expected: "By=hi"},
+		{Element: envoyutil.XFCCElement{Hash: "1389ab1"}, Expected: "Hash=1389ab1"},
+		{Element: envoyutil.XFCCElement{Cert: "anything-goes"}, Expected: "Cert=anything-goes"},
+		{Element: envoyutil.XFCCElement{Chain: "anything-goes"}, Expected: "Chain=anything-goes"},
 		{
-			Element:  &envoyutil.XFCCElement{Subject: "OU=Blent/CN=Test Client"},
+			Element:  envoyutil.XFCCElement{Subject: "OU=Blent/CN=Test Client"},
 			Expected: `Subject="OU=Blent/CN=Test Client"`,
 		},
-		{Element: &envoyutil.XFCCElement{URI: "bye"}, Expected: "URI=bye"},
+		{Element: envoyutil.XFCCElement{URI: "bye"}, Expected: "URI=bye"},
 		{
-			Element:  &envoyutil.XFCCElement{DNS: []string{"web.invalid", "bye.invalid"}},
+			Element:  envoyutil.XFCCElement{DNS: []string{"web.invalid", "bye.invalid"}},
 			Expected: "DNS=web.invalid;DNS=bye.invalid",
 		},
 	}
 	for _, tc := range testCases {
 		asString := tc.Element.String()
 		assert.Equal(tc.Expected, asString)
-		parsed, err := envoyutil.ParseXFCCElement(asString)
+		parsed, err := envoyutil.ParseXFCC(asString)
 		assert.Nil(err)
-		assert.Equal(tc.Element, &parsed)
+		assert.Equal(envoyutil.XFCC{tc.Element}, parsed)
 	}
 
-	// NOTE: For quoting and unquoting, `ParseXFCCElement()` is not fully an
+	// NOTE: For quoting and unquoting, `ParseXFCC()` is not fully an
 	//       inverse to `XFCCElement.String()`.
 	xe := envoyutil.XFCCElement{By: "a,b=10", URI: `c; "then" again`}
 	assert.Equal("By=\"a,b=10\";URI=\"c; \\\"then\\\" again\"", xe.String())
 }
 
-func TestParseXFCCElement(t *testing.T) {
+func TestParseXFCC(t *testing.T) {
 	assert := sdkAssert.New(t)
 
-	ele, err := envoyutil.ParseXFCCElement(xfccElementByTest)
+	ele, err := envoyutil.ParseXFCC(xfccElementByTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{By: "spiffe://cluster.local/ns/blend/sa/tide"}, ele)
+	expected := envoyutil.XFCC{
+		envoyutil.XFCCElement{By: "spiffe://cluster.local/ns/blend/sa/tide"},
+	}
+	assert.Equal(expected, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementByTest + ";" + xfccElementByTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementByTest + ";" + xfccElementByTest)
 	except, ok := err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -285,13 +288,18 @@ func TestParseXFCCElement(t *testing.T) {
 		StackTrace: except.StackTrace,
 	}
 	assert.Equal(expectedErr, except)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementHashTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementHashTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688"}, ele)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+		},
+	}
+	assert.Equal(expected, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementHashTest + ";" + xfccElementHashTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementHashTest + ";" + xfccElementHashTest)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -302,11 +310,16 @@ func TestParseXFCCElement(t *testing.T) {
 	}
 	assert.Equal(expectedErr, except)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementCertTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementCertTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{Cert: xfccElementTestCertEncoded}, ele)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			Cert: xfccElementTestCertEncoded,
+		},
+	}
+	assert.Equal(expected, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementCertTest + ";" + xfccElementCertTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementCertTest + ";" + xfccElementCertTest)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -317,11 +330,16 @@ func TestParseXFCCElement(t *testing.T) {
 	}
 	assert.Equal(expectedErr, except)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementChainTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementChainTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{Chain: xfccElementTestCertEncoded}, ele)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			Chain: xfccElementTestCertEncoded,
+		},
+	}
+	assert.Equal(expected, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementChainTest + ";" + xfccElementChainTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementChainTest + ";" + xfccElementChainTest)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -332,11 +350,16 @@ func TestParseXFCCElement(t *testing.T) {
 	}
 	assert.Equal(expectedErr, except)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementSubjectTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementSubjectTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{Subject: "/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client"}, ele)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			Subject: "/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client",
+		},
+	}
+	assert.Equal(expected, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementSubjectTest + ";" + xfccElementSubjectTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementSubjectTest + ";" + xfccElementSubjectTest)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -347,11 +370,16 @@ func TestParseXFCCElement(t *testing.T) {
 	}
 	assert.Equal(expectedErr, except)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementURITest)
+	ele, err = envoyutil.ParseXFCC(xfccElementURITest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{URI: "spiffe://cluster.local/ns/blend/sa/quasar"}, ele)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			URI: "spiffe://cluster.local/ns/blend/sa/quasar",
+		},
+	}
+	assert.Equal(expected, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementURITest + ";" + xfccElementURITest)
+	ele, err = envoyutil.ParseXFCC(xfccElementURITest + ";" + xfccElementURITest)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -361,79 +389,108 @@ func TestParseXFCCElement(t *testing.T) {
 		StackTrace: except.StackTrace,
 	}
 	assert.Equal(expectedErr, except)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementDNSTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementDNSTest)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{DNS: []string{"http://frontend.lyft.com"}}, ele)
-
-	ele, err = envoyutil.ParseXFCCElement("dns=web.invalid;dns=blend.local.invalid")
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{DNS: []string{"web.invalid", "blend.local.invalid"}}, ele)
-
-	_, err = envoyutil.ParseXFCCElement(xfccElementNoneTest)
-	assert.NotNil(err)
-	except, ok = err.(*ex.Ex)
-	assert.True(ok)
-	assert.NotNil(except)
-	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
-
-	ele, err = envoyutil.ParseXFCCElement(xfccElementMultiTest)
-	assert.Nil(err)
-	expected := envoyutil.XFCCElement{
-		By:   "spiffe://cluster.local/ns/blend/sa/laser",
-		Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			DNS: []string{"http://frontend.lyft.com"},
+		},
 	}
 	assert.Equal(expected, ele)
 
-	_, err = envoyutil.ParseXFCCElement(xfccElementMalformedKeyTest)
+	ele, err = envoyutil.ParseXFCC("dns=web.invalid;dns=blend.local.invalid")
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			DNS: []string{"web.invalid", "blend.local.invalid"},
+		},
+	}
+	assert.Equal(expected, ele)
+
+	_, err = envoyutil.ParseXFCC(xfccElementNoneTest)
 	assert.NotNil(err)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
 	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
 
-	_, err = envoyutil.ParseXFCCElement(xfccElementMultiMalformedKeyTest)
+	ele, err = envoyutil.ParseXFCC(xfccElementMultiTest)
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			By:   "spiffe://cluster.local/ns/blend/sa/laser",
+			Hash: "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
+		},
+	}
+	assert.Equal(expected, ele)
+
+	_, err = envoyutil.ParseXFCC(xfccElementMalformedKeyTest)
 	assert.NotNil(err)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
 	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
 
-	ele, err = envoyutil.ParseXFCCElement(xfccElementEndTest)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{DNS: []string{"http://frontend.lyft.com"}}, ele)
-
-	ele, err = envoyutil.ParseXFCCElement("cert=" + xfccElementMalformedEncoding)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{Cert: "%"}, ele)
-
-	ele, err = envoyutil.ParseXFCCElement("chain=" + xfccElementMalformedEncoding)
-	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{Chain: "%"}, ele)
-
-	ele, err = envoyutil.ParseXFCCElement("=;")
+	_, err = envoyutil.ParseXFCC(xfccElementMultiMalformedKeyTest)
 	assert.NotNil(err)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
 	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+
+	ele, err = envoyutil.ParseXFCC(xfccElementEndTest)
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			DNS: []string{"http://frontend.lyft.com"},
+		},
+	}
+	assert.Equal(expected, ele)
+
+	ele, err = envoyutil.ParseXFCC("cert=" + xfccElementMalformedEncoding)
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			Cert: "%",
+		},
+	}
+	assert.Equal(expected, ele)
+
+	ele, err = envoyutil.ParseXFCC("chain=" + xfccElementMalformedEncoding)
+	assert.Nil(err)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			Chain: "%",
+		},
+	}
+	assert.Equal(expected, ele)
+
+	ele, err = envoyutil.ParseXFCC("=;")
+	assert.NotNil(err)
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	// Test empty subject
-	ele, err = envoyutil.ParseXFCCElement(`By=spiffe://cluster.local/ns/blend/sa/protocol;Hash=52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129;Subject="";URI=spiffe://cluster.local/ns/blend/sa/world`)
+	ele, err = envoyutil.ParseXFCC(`By=spiffe://cluster.local/ns/blend/sa/protocol;Hash=52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129;Subject="";URI=spiffe://cluster.local/ns/blend/sa/world`)
 	assert.Nil(err)
-	expected = envoyutil.XFCCElement{
-		By:      "spiffe://cluster.local/ns/blend/sa/protocol",
-		Hash:    "52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129",
-		Subject: "",
-		URI:     "spiffe://cluster.local/ns/blend/sa/world",
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			By:      "spiffe://cluster.local/ns/blend/sa/protocol",
+			Hash:    "52114972613efb0820c5e32bfee0f0ee2a84859f7169da6c222300ef852a1129",
+			Subject: "",
+			URI:     "spiffe://cluster.local/ns/blend/sa/world",
+		},
 	}
 	assert.Equal(expected, ele)
 
 	// Quoted value with empty key.
-	ele, err = envoyutil.ParseXFCCElement(`="a";b=20`)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	ele, err = envoyutil.ParseXFCC(`="a";b=20`)
+	assert.Equal(envoyutil.XFCC{}, ele)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -445,8 +502,8 @@ func TestParseXFCCElement(t *testing.T) {
 	assert.Equal(expectedErr, except)
 
 	// Quoted value with invalid key.
-	ele, err = envoyutil.ParseXFCCElement(`wrong="quoted";by=next`)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	ele, err = envoyutil.ParseXFCC(`wrong="quoted";by=next`)
+	assert.Equal(envoyutil.XFCC{}, ele)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -458,8 +515,8 @@ func TestParseXFCCElement(t *testing.T) {
 	assert.Equal(expectedErr, except)
 
 	// Closing quoted not following by `;`
-	ele, err = envoyutil.ParseXFCCElement(`a="b"---`)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
+	ele, err = envoyutil.ParseXFCC(`a="b"---`)
+	assert.Equal(envoyutil.XFCC{}, ele)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -471,35 +528,29 @@ func TestParseXFCCElement(t *testing.T) {
 	assert.Equal(expectedErr, except)
 
 	// Escaped quotes and other characters work as expected.
-	ele, err = envoyutil.ParseXFCCElement(`By="a,b=10";URI="c; \"then\" again"`)
+	ele, err = envoyutil.ParseXFCC(`By="a,b=10";URI="c; \"then\" again"`)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{By: "a,b=10", URI: `c; "then" again`}, ele)
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			By:  "a,b=10",
+			URI: `c; "then" again`,
+		},
+	}
+	assert.Equal(expected, ele)
 
 	// Bare escape character works fine (when not followed by a quote).
-	ele, err = envoyutil.ParseXFCCElement(`By="first\tsecond"`)
+	ele, err = envoyutil.ParseXFCC(`By="first\tsecond"`)
 	assert.Nil(err)
-	assert.Equal(envoyutil.XFCCElement{By: "first\\tsecond"}, ele)
-
-	// COVERAGE for legacy stub.
-	ele, err = envoyutil.ParseXFCCElement(`By=a,URI=b`)
-	except, ok = err.(*ex.Ex)
-	assert.True(ok)
-	assert.NotNil(except)
-	expectedErr = &ex.Ex{
-		Class:      envoyutil.ErrXFCCParsing,
-		Message:    "WRENCH",
-		StackTrace: except.StackTrace,
+	expected = envoyutil.XFCC{
+		envoyutil.XFCCElement{
+			By: "first\\tsecond",
+		},
 	}
-	assert.Equal(expectedErr, except)
-	assert.Equal(envoyutil.XFCCElement{}, ele)
-}
-
-func TestParseXFCC(t *testing.T) {
-	assert := sdkAssert.New(t)
+	assert.Equal(expected, ele)
 
 	xfcc, err := envoyutil.ParseXFCC(fullXFCCTest + "," + fullXFCCTest)
 	assert.Nil(err)
-	expected := envoyutil.XFCC{
+	expected = envoyutil.XFCC{
 		envoyutil.XFCCElement{
 			By:      "spiffe://cluster.local/ns/blend/sa/yule",
 			Hash:    "468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688",
@@ -515,12 +566,17 @@ func TestParseXFCC(t *testing.T) {
 	}
 	assert.Equal(expected, xfcc)
 
-	_, err = envoyutil.ParseXFCC(xfccElementMalformedKeyTest)
-	assert.NotNil(err)
-	except, ok := err.(*ex.Ex)
+	ele, err = envoyutil.ParseXFCC(xfccElementMalformedKeyTest)
+	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
-	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    "Key or value found but not both",
+		StackTrace: except.StackTrace,
+	}
+	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	// Quoted value at element boundary.
 	xfcc, err = envoyutil.ParseXFCC(`by="me",uri=you`)

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -239,7 +239,6 @@ func TestXFCCElementString(t *testing.T) {
 		Expected string
 	}
 	testCases := []testCase{
-		{Element: envoyutil.XFCCElement{}, Expected: ""},
 		{Element: envoyutil.XFCCElement{By: "hi"}, Expected: "By=hi"},
 		{Element: envoyutil.XFCCElement{Hash: "1389ab1"}, Expected: "Hash=1389ab1"},
 		{Element: envoyutil.XFCCElement{Cert: "anything-goes"}, Expected: "Cert=anything-goes"},
@@ -265,6 +264,10 @@ func TestXFCCElementString(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(envoyutil.XFCC{tc.Element}, parsed)
 	}
+
+	element := envoyutil.XFCCElement{}
+	asString := element.String()
+	assert.Equal("", asString)
 }
 
 func TestParseXFCC(t *testing.T) {
@@ -440,13 +443,16 @@ func TestParseXFCC(t *testing.T) {
 	assert.Equal(envoyutil.ErrXFCCParsing, except.Class)
 
 	ele, err = envoyutil.ParseXFCC(xfccElementEndTest)
-	assert.Nil(err)
-	expected = envoyutil.XFCC{
-		envoyutil.XFCCElement{
-			DNS: []string{"http://frontend.lyft.com"},
-		},
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    "Ends with separator character",
+		StackTrace: except.StackTrace,
 	}
-	assert.Equal(expected, ele)
+	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	ele, err = envoyutil.ParseXFCC("cert=" + xfccElementMalformedEncoding)
 	assert.Nil(err)
@@ -588,18 +594,32 @@ func TestParseXFCC(t *testing.T) {
 
 	// KV separator is the last character
 	xfcc, err = envoyutil.ParseXFCC("by=cliffhanger;")
-	assert.Nil(err)
-	expected = envoyutil.XFCC{
-		envoyutil.XFCCElement{By: "cliffhanger"},
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    "Ends with separator character",
+		StackTrace: except.StackTrace,
 	}
-	assert.Equal(expected, xfcc)
+	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	// Element separator is the last character
 	xfcc, err = envoyutil.ParseXFCC("uri=cliffhanger,")
-	assert.Nil(err)
-	expected = envoyutil.XFCC{
-		envoyutil.XFCCElement{URI: "cliffhanger"},
-		envoyutil.XFCCElement{},
+	except, ok = err.(*ex.Ex)
+	assert.True(ok)
+	assert.NotNil(except)
+	expectedErr = &ex.Ex{
+		Class:      envoyutil.ErrXFCCParsing,
+		Message:    "Ends with separator character",
+		StackTrace: except.StackTrace,
 	}
-	assert.Equal(expected, xfcc)
+	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
+
+	// Empty header
+	xfcc, err = envoyutil.ParseXFCC("")
+	assert.Nil(err)
+	assert.Equal(envoyutil.XFCC{}, ele)
 }

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -253,6 +253,10 @@ func TestXFCCElementString(t *testing.T) {
 			Element:  envoyutil.XFCCElement{DNS: []string{"web.invalid", "bye.invalid"}},
 			Expected: "DNS=web.invalid;DNS=bye.invalid",
 		},
+		{
+			Element:  envoyutil.XFCCElement{By: "a,b=10", URI: `c; "then" again`},
+			Expected: "By=\"a,b=10\";URI=\"c; \\\"then\\\" again\"",
+		},
 	}
 	for _, tc := range testCases {
 		asString := tc.Element.String()
@@ -261,11 +265,6 @@ func TestXFCCElementString(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(envoyutil.XFCC{tc.Element}, parsed)
 	}
-
-	// NOTE: For quoting and unquoting, `ParseXFCC()` is not fully an
-	//       inverse to `XFCCElement.String()`.
-	xe := envoyutil.XFCCElement{By: "a,b=10", URI: `c; "then" again`}
-	assert.Equal("By=\"a,b=10\";URI=\"c; \\\"then\\\" again\"", xe.String())
 }
 
 func TestParseXFCC(t *testing.T) {


### PR DESCRIPTION
## PR Summary

 - **Type:** Improvements
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.