### PR TITLE
Using `context.Context` for storing Envoy client identity instead of `web.Ctx`.

### DIFF
--- a/envoyutil/middleware_test.go
+++ b/envoyutil/middleware_test.go
@@ -1,6 +1,7 @@
 package envoyutil_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -12,22 +13,13 @@ import (
 	"github.com/blend/go-sdk/envoyutil"
 )
 
-func TestGetClientIdentity(t *testing.T) {
+func TestWithClientIdentity(t *testing.T) {
 	assert := sdkAssert.New(t)
 
-	ctx := web.MockCtx("GET", "/")
+	ctx := context.Background()
+	newCtx := envoyutil.WithClientIdentity(ctx, "web.site")
 	assert.Empty(envoyutil.GetClientIdentity(ctx))
-
-	ctx.WithStateValue(envoyutil.StateKeyClientIdentity, nil)
-	assert.Empty(envoyutil.GetClientIdentity(ctx))
-
-	ctx.WithStateValue(envoyutil.StateKeyClientIdentity, 42)
-	assert.Empty(envoyutil.GetClientIdentity(ctx))
-
-	wi := "hello.world"
-	ctx.WithStateValue(envoyutil.StateKeyClientIdentity, wi)
-	assert.NotNil(envoyutil.GetClientIdentity(ctx))
-	assert.Equal(wi, envoyutil.GetClientIdentity(ctx))
+	assert.Equal("web.site", envoyutil.GetClientIdentity(newCtx))
 }
 
 func TestClientIdentityRequired(t *testing.T) {
@@ -109,7 +101,7 @@ func TestClientIdentityRequired(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(http.StatusOK, meta.StatusCode, "Success on valid header")
 	assert.NotNil(capturedContext)
-	assert.Equal("twtr.blend", envoyutil.GetClientIdentity(capturedContext))
+	assert.Equal("twtr.blend", envoyutil.GetClientIdentity(capturedContext.Context()))
 	capturedContext = nil
 
 	xfcc = `By=mailto:John.Doe@example.com;URI=spiffe://cluster.local/ns/blend/sa/peas`

--- a/envoyutil/xfcc_test.go
+++ b/envoyutil/xfcc_test.go
@@ -317,6 +317,7 @@ func TestParseXFCC(t *testing.T) {
 		StackTrace: except.StackTrace,
 	}
 	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	ele, err = envoyutil.ParseXFCC(xfccElementCertTest)
 	assert.Nil(err)
@@ -337,6 +338,7 @@ func TestParseXFCC(t *testing.T) {
 		StackTrace: except.StackTrace,
 	}
 	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	ele, err = envoyutil.ParseXFCC(xfccElementChainTest)
 	assert.Nil(err)
@@ -357,6 +359,7 @@ func TestParseXFCC(t *testing.T) {
 		StackTrace: except.StackTrace,
 	}
 	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	ele, err = envoyutil.ParseXFCC(xfccElementSubjectTest)
 	assert.Nil(err)
@@ -377,6 +380,7 @@ func TestParseXFCC(t *testing.T) {
 		StackTrace: except.StackTrace,
 	}
 	assert.Equal(expectedErr, except)
+	assert.Equal(envoyutil.XFCC{}, ele)
 
 	ele, err = envoyutil.ParseXFCC(xfccElementURITest)
 	assert.Nil(err)
@@ -600,6 +604,7 @@ func TestParseXFCC(t *testing.T) {
 
 	// KV separator is the last character
 	xfcc, err = envoyutil.ParseXFCC("by=cliffhanger;")
+	assert.Equal(envoyutil.XFCC{}, xfcc)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -613,6 +618,7 @@ func TestParseXFCC(t *testing.T) {
 
 	// Element separator is the last character
 	xfcc, err = envoyutil.ParseXFCC("uri=cliffhanger,")
+	assert.Equal(envoyutil.XFCC{}, xfcc)
 	except, ok = err.(*ex.Ex)
 	assert.True(ok)
 	assert.NotNil(except)
@@ -626,6 +632,7 @@ func TestParseXFCC(t *testing.T) {
 
 	// Empty header
 	xfcc, err = envoyutil.ParseXFCC("")
+	assert.Equal(envoyutil.XFCC{}, xfcc)
 	assert.Nil(err)
 	assert.Equal(envoyutil.XFCC{}, ele)
 }


### PR DESCRIPTION
## PR Summary

 - **Type:** Features
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.