### PR TITLE
Fixing `db.Config.Resolve()` to pull from `DB_LOCK_TIMEOUT` and `DB_STATEMENT_TIMEOUT`.

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -61,14 +61,22 @@ func NewConfigFromDSN(dsn string) (*Config, error) {
 
 // NewConfigFromEnv returns a new config from the environment.
 // The environment variable mappings are as follows:
-//	-	DATABSE_URL 	= DSN 	//note that this has precedence over other vars (!!)
-// 	-	DB_HOST 		= Host
-//	-	DB_PORT 		= Port
-//	- 	DB_NAME 		= Database
-//	-	DB_SCHEMA		= Schema
-//	-	DB_USER 		= Username
-//	-	DB_PASSWORD 	= Password
-//	-	DB_SSLMODE 		= SSLMode
+// 	-	DB_ENGINE            = Engine
+//	-	DATABASE_URL         = DSN     //note that this has precedence over other vars (!!)
+// 	-	DB_HOST              = Host
+//	-	DB_PORT              = Port
+//	- 	DB_NAME              = Database
+//	-	DB_SCHEMA            = Schema
+//	-	DB_USER              = Username
+//	-	DB_PASSWORD          = Password
+//	-	DB_CONNECT_TIMEOUT   = ConnectTimeout
+//	-	DB_LOCK_TIMEOUT      = LockTimeout
+//	-	DB_STATEMENT_TIMEOUT = StatementTimeout
+//	-	DB_SSLMODE           = SSLMode
+//	-	DB_IDLE_CONNECTIONS  = IdleConnections
+//	-	DB_MAX_CONNECTIONS   = MaxConnections
+//	-	DB_MAX_LIFETIME      = MaxLifetime
+//	-	DB_BUFFER_POOL_SIZE  = BufferPoolSize
 func NewConfigFromEnv() (config Config, err error) {
 	if err = (&config).Resolve(env.WithVars(context.Background(), env.Env())); err != nil {
 		return
@@ -164,6 +172,8 @@ func (c *Config) Resolve(ctx context.Context) error {
 		configutil.SetString(&c.Username, configutil.Env("DB_USER"), configutil.String(c.Username), configutil.Env("USER")),
 		configutil.SetString(&c.Password, configutil.Env("DB_PASSWORD"), configutil.String(c.Password)),
 		configutil.SetInt(&c.ConnectTimeout, configutil.Env("DB_CONNECT_TIMEOUT"), configutil.Int(c.ConnectTimeout), configutil.Int(DefaultConnectTimeout)),
+		configutil.SetDuration(&c.LockTimeout, configutil.Env("DB_LOCK_TIMEOUT"), configutil.Duration(c.LockTimeout)),
+		configutil.SetDuration(&c.StatementTimeout, configutil.Env("DB_STATEMENT_TIMEOUT"), configutil.Duration(c.StatementTimeout)),
 		configutil.SetString(&c.SSLMode, configutil.Env("DB_SSLMODE"), configutil.String(c.SSLMode)),
 		configutil.SetInt(&c.IdleConnections, configutil.Env("DB_IDLE_CONNECTIONS"), configutil.Int(c.IdleConnections), configutil.Int(DefaultIdleConnections)),
 		configutil.SetInt(&c.MaxConnections, configutil.Env("DB_MAX_CONNECTIONS"), configutil.Int(c.MaxConnections), configutil.Int(DefaultMaxConnections)),

--- a/examples/db/prevent-deadlock/README.md
+++ b/examples/db/prevent-deadlock/README.md
@@ -73,8 +73,6 @@ $ go run .
 0.261803 Error(s):
 0.261852 - &pq.Error{Severity:"ERROR", Code:"55P03", Message:"canceling statement due to lock timeout", Detail:"", Hint:"", Position:"", InternalPosition:"", InternalQuery:"", Where:"while updating tuple (0,2) in relation \"might_deadlock\"", Schema:"", Table:"", Column:"", DataTypeName:"", Constraint:"", File:"postgres.c", Line:"2989", Routine:"ProcessInterrupts"}
 0.261862 - &pq.Error{Severity:"ERROR", Code:"55P03", Message:"canceling statement due to lock timeout", Detail:"", Hint:"", Position:"", InternalPosition:"", InternalQuery:"", Where:"while updating tuple (0,1) in relation \"might_deadlock\"", Schema:"", Table:"", Column:"", DataTypeName:"", Constraint:"", File:"postgres.c", Line:"2989", Routine:"ProcessInterrupts"}
-0.261870 - &errors.errorString{s:"pq: Could not complete operation in a failed transaction"}
-0.261874 - &errors.errorString{s:"pq: Could not complete operation in a failed transaction"}
 ```
 
 From [Appendix A. PostgreSQL Error Codes][1]:
@@ -106,7 +104,6 @@ $ FORCE_DEADLOCK=true go run .
 1.245005 ***
 1.245016 Error(s):
 1.245053 - &pq.Error{Severity:"ERROR", Code:"40P01", Message:"deadlock detected", Detail:"Process 347 waits for ShareLock on transaction 845; blocked by process 346.\nProcess 346 waits for ShareLock on transaction 846; blocked by process 347.", Hint:"See server log for query details.", Position:"", InternalPosition:"", InternalQuery:"", Where:"while updating tuple (0,1) in relation \"might_deadlock\"", Schema:"", Table:"", Column:"", DataTypeName:"", Constraint:"", File:"deadlock.c", Line:"1140", Routine:"DeadLockReport"}
-1.245063 - &errors.errorString{s:"pq: Could not complete operation in a failed transaction"}
 ```
 
 From [Appendix A. PostgreSQL Error Codes][1]:
@@ -138,8 +135,6 @@ $ BETWEEN_QUERIES=true go run .
 0.236587 - Context cancel in between queries
 0.236591 - context.deadlineExceededError{}
 0.236615 - Context cancel in between queries
-0.236636 - &errors.errorString{s:"sql: transaction has already been committed or rolled back"}
-0.236643 - &errors.errorString{s:"sql: transaction has already been committed or rolled back"}
 ```
 
 ## Cancel "Stuck" Deadlock via Go `context` Cancelation
@@ -161,8 +156,6 @@ $ DISABLE_LOCK_TIMEOUT=true go run .
 0.612474 Error(s):
 0.612539 - &pq.Error{Severity:"ERROR", Code:"57014", Message:"canceling statement due to user request", Detail:"", Hint:"", Position:"", InternalPosition:"", InternalQuery:"", Where:"while updating tuple (0,2) in relation \"might_deadlock\"", Schema:"", Table:"", Column:"", DataTypeName:"", Constraint:"", File:"postgres.c", Line:"3026", Routine:"ProcessInterrupts"}
 0.612556 - &pq.Error{Severity:"ERROR", Code:"57014", Message:"canceling statement due to user request", Detail:"", Hint:"", Position:"", InternalPosition:"", InternalQuery:"", Where:"while updating tuple (0,1) in relation \"might_deadlock\"", Schema:"", Table:"", Column:"", DataTypeName:"", Constraint:"", File:"postgres.c", Line:"3026", Routine:"ProcessInterrupts"}
-0.612569 - &errors.errorString{s:"sql: transaction has already been committed or rolled back"}
-0.612578 - &errors.errorString{s:"sql: transaction has already been committed or rolled back"}
 ```
 
 From [Appendix A. PostgreSQL Error Codes][1]:

--- a/examples/db/prevent-deadlock/README.md
+++ b/examples/db/prevent-deadlock/README.md
@@ -63,7 +63,7 @@ $ go run .
 0.000089 Configured context timeout:   600ms
 0.000091 Configured transaction sleep: 200ms
 0.000114 ==================================================
-0.014372 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?lock_timeout=10ms&sslmode=disable"
+0.014372 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&lock_timeout=10ms&sslmode=disable"
 0.014381 ==================================================
 0.015569 lock_timeout=10ms
 0.026958 ==================================================
@@ -97,7 +97,7 @@ $ FORCE_DEADLOCK=true go run .
 0.000071 Configured context timeout:   10s
 0.000073 Configured transaction sleep: 200ms
 0.000089 ==================================================
-0.011839 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?lock_timeout=10000ms&sslmode=disable"
+0.011839 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&lock_timeout=10000ms&sslmode=disable"
 0.011850 ==================================================
 0.013332 lock_timeout=10s
 0.022643 ==================================================
@@ -126,7 +126,7 @@ $ BETWEEN_QUERIES=true go run .
 0.000086 Configured context timeout:   100ms
 0.000089 Configured transaction sleep: 200ms
 0.000110 ==================================================
-0.013163 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?lock_timeout=10000ms&sslmode=disable"
+0.013163 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&lock_timeout=10000ms&sslmode=disable"
 0.013176 ==================================================
 0.014402 lock_timeout=10s
 0.025375 ==================================================
@@ -151,7 +151,7 @@ $ DISABLE_LOCK_TIMEOUT=true go run .
 0.000088 Configured context timeout:   600ms
 0.000091 Configured transaction sleep: 200ms
 0.000113 ==================================================
-0.014431 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?lock_timeout=10000ms&sslmode=disable"
+0.014431 DSN="postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&lock_timeout=10000ms&sslmode=disable"
 0.014442 ==================================================
 0.016239 lock_timeout=10s
 0.026890 ==================================================
@@ -178,11 +178,11 @@ Class 57 - Operator Intervention
 See `libpq` [Parameter Key Words][2]
 
 ```
-$ psql "postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?lock_timeout=10ms&sslmode=disable"
+$ psql "postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&lock_timeout=10ms&sslmode=disable"
 psql: error: could not connect to server: invalid URI query parameter: "lock_timeout"
 $
 $
-$ psql "postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?sslmode=disable"
+$ psql "postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&sslmode=disable"
 ...
 superuser_db=# SHOW lock_timeout;
  lock_timeout
@@ -193,7 +193,7 @@ superuser_db=# SHOW lock_timeout;
 superuser_db=# \q
 $
 $
-$ PGOPTIONS="-c lock_timeout=4500ms" psql "postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?sslmode=disable"
+$ PGOPTIONS="-c lock_timeout=4500ms" psql "postgres://superuser:testpassword_superuser@localhost:28007/superuser_db?connect_timeout=5&sslmode=disable"
 ...
 superuser_db=# SHOW lock_timeout;
  lock_timeout

--- a/examples/db/prevent-deadlock/main.go
+++ b/examples/db/prevent-deadlock/main.go
@@ -92,6 +92,10 @@ func intentionalContention(ctx context.Context, pool *db.Connection, cfg *config
 	}()
 	wg.Wait()
 
+	if err != nil {
+		return
+	}
+
 	// Make sure to commit both transactions before moving on.
 	err = nest(err, tx1.Commit())
 	err = nest(err, tx2.Commit())

--- a/examples/db/prevent-deadlock/multi.go
+++ b/examples/db/prevent-deadlock/multi.go
@@ -27,16 +27,26 @@ func (me *multiError) Error() string {
 }
 
 func nest(err1, err2 error) error {
-	if err1 == nil {
-		return err2
-	}
-	if err2 == nil {
-		return err1
-	}
-
 	// We know below here that both errors are non-nil.
 	asMulti1, ok1 := err1.(*multiError)
 	asMulti2, ok2 := err2.(*multiError)
+
+	if err1 == nil {
+		if err2 == nil {
+			return nil
+		}
+		if ok2 {
+			return err2
+		}
+		return &multiError{Errors: []error{err2}}
+	}
+
+	if err2 == nil {
+		if ok1 {
+			return err1
+		}
+		return &multiError{Errors: []error{err1}}
+	}
 
 	if ok1 {
 		if ok2 {

--- a/examples/db/statement-timeout/README.md
+++ b/examples/db/statement-timeout/README.md
@@ -48,7 +48,7 @@ $ go run .
 0.000095 Configured pg_sleep:          200ms
 0.000098 Configured context timeout:   400ms
 0.000124 ==================================================
-0.015619 DSN="postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?sslmode=disable&statement_timeout=10ms"
+0.015619 DSN="postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?connect_timeout=5&sslmode=disable&statement_timeout=10ms"
 0.015629 ==================================================
 0.016960 statement_timeout=10ms
 0.024797 ==================================================
@@ -76,7 +76,7 @@ $ VIA_GO_CONTEXT=true go run .
 0.000120 Configured pg_sleep:          200ms
 0.000133 Configured context timeout:   100ms
 0.000163 ==================================================
-0.014563 DSN="postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?sslmode=disable&statement_timeout=10000ms"
+0.014563 DSN="postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?connect_timeout=5&sslmode=disable&statement_timeout=10000ms"
 0.014575 ==================================================
 0.016120 statement_timeout=10s
 0.023707 ==================================================
@@ -92,11 +92,11 @@ $ VIA_GO_CONTEXT=true go run .
 See `libpq` [Parameter Key Words][2]
 
 ```
-$ psql "postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?sslmode=disable&statement_timeout=10ms"
+$ psql "postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?connect_timeout=5&sslmode=disable&statement_timeout=10ms"
 psql: error: could not connect to server: invalid URI query parameter: "statement_timeout"
 $
 $
-$ psql "postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?sslmode=disable"
+$ psql "postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?connect_timeout=5&sslmode=disable"
 ...
 superuser_db=# SHOW statement_timeout;
  statement_timeout
@@ -107,7 +107,7 @@ superuser_db=# SHOW statement_timeout;
 superuser_db=# \q
 $
 $
-$ PGOPTIONS="-c statement_timeout=5500ms" psql "postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?sslmode=disable"
+$ PGOPTIONS="-c statement_timeout=5500ms" psql "postgres://superuser:testpassword_superuser@localhost:30071/superuser_db?connect_timeout=5&sslmode=disable"
 ...
 superuser_db=# SHOW statement_timeout;
  statement_timeout


### PR DESCRIPTION
## PR Summary

In the process also updating examples to ditch `tx.Commit()` in situations where an error has already occurred.

 - **Type:** Bugfix
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.