### PR TITLE
Dont exit coverage when ensureCoverage does not meet thresholds

### DIFF
--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -41,7 +41,7 @@ var covermode = flag.String("covermode", "atomic", "the go test covermode.")
 var coverprofile = flag.String("coverprofile", "coverage.cov", "the intermediate cover profile.")
 var keepCoverageOut = flag.Bool("keep-coverage-out", false, "if we should keep coverage.out")
 var v = flag.Bool("v", false, "show verbose output")
-var disableEarlyExitOnCoverageFailure = flag.Bool("include-coverage-report-failures", false, "enable to produce coverage reports when coverage fails")
+var disableEarlyExitOnCoverageFailure = flag.Bool("exit-first", false, "enable to produce coverage reports when coverage fails")
 
 var (
 	includes Paths

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -41,7 +41,7 @@ var covermode = flag.String("covermode", "atomic", "the go test covermode.")
 var coverprofile = flag.String("coverprofile", "coverage.cov", "the intermediate cover profile.")
 var keepCoverageOut = flag.Bool("keep-coverage-out", false, "if we should keep coverage.out")
 var v = flag.Bool("v", false, "show verbose output")
-var disableEarlyExitOnCoverageFailure = flag.Bool("exit-first", false, "enable to produce coverage reports when coverage fails")
+var exitOnFirstCoverageFailure = flag.Bool("exit-first", true, "enable to produce coverage reports when coverage fails")
 
 var (
 	includes Paths
@@ -134,7 +134,7 @@ func walkPath(walkedPath string, fullCoverageData *os.File) []error {
 	maybeFatal(filepath.Walk(rootPath, func(currentPath string, info os.FileInfo, fileErr error) error {
 		packageCoverReport, err := getPackageCoverage(currentPath, info, fileErr)
 
-		if err != nil && !*disableEarlyExitOnCoverageFailure {
+		if err != nil && *exitOnFirstCoverageFailure {
 			return err
 		}
 

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -41,7 +41,7 @@ var covermode = flag.String("covermode", "atomic", "the go test covermode.")
 var coverprofile = flag.String("coverprofile", "coverage.cov", "the intermediate cover profile.")
 var keepCoverageOut = flag.Bool("keep-coverage-out", false, "if we should keep coverage.out")
 var v = flag.Bool("v", false, "show verbose output")
-var exitOnFirstCoverageFailure = flag.Bool("exit-first", true, "enable to produce coverage reports when coverage fails")
+var exitOnFirstCoverageFailure = flag.Bool("exit-first", true, "disable flag to produce coverage reports when coverage fails")
 
 var (
 	includes Paths

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -41,7 +41,7 @@ var covermode = flag.String("covermode", "atomic", "the go test covermode.")
 var coverprofile = flag.String("coverprofile", "coverage.cov", "the intermediate cover profile.")
 var keepCoverageOut = flag.Bool("keep-coverage-out", false, "if we should keep coverage.out")
 var v = flag.Bool("v", false, "show verbose output")
-var disableEarlyExitOnCoverageFailure = flag.Bool("include coverage.html on coverage failure", false, "enable to produce coverage reports when coverage fails")
+var disableEarlyExitOnCoverageFailure = flag.Bool("include-coverage-report-failures", false, "enable to produce coverage reports when coverage fails")
 
 var (
 	includes Paths

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -41,7 +41,7 @@ var covermode = flag.String("covermode", "atomic", "the go test covermode.")
 var coverprofile = flag.String("coverprofile", "coverage.cov", "the intermediate cover profile.")
 var keepCoverageOut = flag.Bool("keep-coverage-out", false, "if we should keep coverage.out")
 var v = flag.Bool("v", false, "show verbose output")
-var exitOnFirstCoverageFailure = flag.Bool("exit-first", true, "disable flag to produce coverage reports when coverage fails")
+var exitOnFirstCoverageFailure = flag.Bool("exit-first", true, "exit on first coverage failure; when disabled this will produce full coverage reports even on coverage failures")
 
 var (
 	includes Paths

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -41,6 +41,7 @@ var covermode = flag.String("covermode", "atomic", "the go test covermode.")
 var coverprofile = flag.String("coverprofile", "coverage.cov", "the intermediate cover profile.")
 var keepCoverageOut = flag.Bool("keep-coverage-out", false, "if we should keep coverage.out")
 var v = flag.Bool("v", false, "show verbose output")
+var disableEarlyExitOnCoverageFailure = flag.Bool("include coverage.html on coverage failure", false, "enable to produce coverage reports when coverage fails")
 
 var (
 	includes Paths
@@ -132,6 +133,11 @@ func walkPath(walkedPath string, fullCoverageData *os.File) []error {
 
 	maybeFatal(filepath.Walk(rootPath, func(currentPath string, info os.FileInfo, fileErr error) error {
 		packageCoverReport, err := getPackageCoverage(currentPath, info, fileErr)
+
+		if err != nil && !*disableEarlyExitOnCoverageFailure {
+			return err
+		}
+
 		if err != nil && len(packageCoverReport) > 0 {
 			coverageErrors = append(coverageErrors, err)
 		}

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -87,7 +87,7 @@ func main() {
 		paths = []string{"./..."}
 	}
 
-	allPathCoverageErrors := []error{}
+	var allPathCoverageErrors []error
 	for _, path := range paths {
 		fmt.Fprintf(os.Stdout, "walking path: %s\n", path)
 		if coverageErrors := walkPath(path, fullCoverageData); len(coverageErrors) > 0 {
@@ -128,7 +128,7 @@ func main() {
 func walkPath(walkedPath string, fullCoverageData *os.File) []error {
 	recursive := strings.HasSuffix(walkedPath, expand)
 	rootPath := filepath.Dir(walkedPath)
-	coverageErrors := []error{}
+	var coverageErrors []error
 
 	maybeFatal(filepath.Walk(rootPath, func(currentPath string, info os.FileInfo, fileErr error) error {
 		packageCoverReport, err := getPackageCoverage(currentPath, info, fileErr)

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -131,7 +131,7 @@ func walkPath(walkedPath string, fullCoverageData *os.File) []error {
 
 	maybeFatal(filepath.Walk(rootPath, func(currentPath string, info os.FileInfo, fileErr error) error {
 		packageCoverReport, err := getPackageCoverage(currentPath, info, fileErr)
-		if err != nil {
+		if err != nil && len(packageCoverReport) > 0 {
 			coverageErrors = append(coverageErrors, err)
 		}
 

--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -115,6 +115,7 @@ func main() {
 	}
 
 	if len(allPathCoverageErrors) > 0 {
+		fmt.Fprintln(os.Stderr, "coverage thresholds not met")
 		for _, coverageError := range allPathCoverageErrors {
 			fmt.Fprintf(os.Stderr, "%+v\n", coverageError)
 		}


### PR DESCRIPTION
## PR Summary

On coverage failures, coverage.html is not generated and cannot be viewed in jenkins

 - **Type:** Bugfix
 - **Issue Link:** https://github.com/blend/go-sdk/issues/??
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.