### PR TITLE
Fixing typo in `db.Config.MaxLifetime` default and removing unused `db.DefaultPlanCacheDisabled`.

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -177,7 +177,7 @@ func (c *Config) Resolve(ctx context.Context) error {
 		configutil.SetString(&c.SSLMode, configutil.Env("DB_SSLMODE"), configutil.String(c.SSLMode)),
 		configutil.SetInt(&c.IdleConnections, configutil.Env("DB_IDLE_CONNECTIONS"), configutil.Int(c.IdleConnections), configutil.Int(DefaultIdleConnections)),
 		configutil.SetInt(&c.MaxConnections, configutil.Env("DB_MAX_CONNECTIONS"), configutil.Int(c.MaxConnections), configutil.Int(DefaultMaxConnections)),
-		configutil.SetDuration(&c.MaxLifetime, configutil.Env("DB_MAX_LIFETIME"), configutil.Duration(c.MaxConnections), configutil.Duration(DefaultMaxLifetime)),
+		configutil.SetDuration(&c.MaxLifetime, configutil.Env("DB_MAX_LIFETIME"), configutil.Duration(c.MaxLifetime), configutil.Duration(DefaultMaxLifetime)),
 		configutil.SetInt(&c.BufferPoolSize, configutil.Env("DB_BUFFER_POOL_SIZE"), configutil.Int(c.BufferPoolSize), configutil.Int(DefaultBufferPoolSize)),
 	)
 }

--- a/db/constants.go
+++ b/db/constants.go
@@ -45,8 +45,6 @@ const (
 	// Postgres Docs: "I want my data encrypted, and I accept the overhead. I want to be sure that I connect to a server I trust, and that it's the one I specify."
 	SSLModeVerifyFull = "verify-full"
 
-	// DefaultPlanCacheDisabled is the default if we should enable the statement cache.
-	DefaultPlanCacheDisabled = false
 	// DefaultIdleConnections is the default number of idle connections.
 	DefaultIdleConnections = 16
 	// DefaultMaxConnections is the default maximum number of connections.


### PR DESCRIPTION
## PR Summary

 - **Type:** Bugfix
 - **Intended Change Level:** patch

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.