### PR TITLE
Adding `db.Config.Application` field to set the `application_name` configuration parameter

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -63,23 +63,23 @@ func NewConfigFromDSN(dsn string) (*Config, error) {
 
 // NewConfigFromEnv returns a new config from the environment.
 // The environment variable mappings are as follows:
-// 	-	DB_ENGINE            = Engine
-//	-	DATABASE_URL         = DSN     //note that this has precedence over other vars (!!)
-// 	-	DB_HOST              = Host
-//	-	DB_PORT              = Port
-//	- 	DB_NAME              = Database
-//	-	DB_SCHEMA            = Schema
-//	-	DB_APPLICATION_NAME  = ApplicationName
-//	-	DB_USER              = Username
-//	-	DB_PASSWORD          = Password
-//	-	DB_CONNECT_TIMEOUT   = ConnectTimeout
-//	-	DB_LOCK_TIMEOUT      = LockTimeout
-//	-	DB_STATEMENT_TIMEOUT = StatementTimeout
-//	-	DB_SSLMODE           = SSLMode
-//	-	DB_IDLE_CONNECTIONS  = IdleConnections
-//	-	DB_MAX_CONNECTIONS   = MaxConnections
-//	-	DB_MAX_LIFETIME      = MaxLifetime
-//	-	DB_BUFFER_POOL_SIZE  = BufferPoolSize
+//  -  DB_ENGINE            = Engine
+//  -  DATABASE_URL         = DSN     //note that this has precedence over other vars (!!)
+//  -  DB_HOST              = Host
+//  -  DB_PORT              = Port
+//  -  DB_NAME              = Database
+//  -  DB_SCHEMA            = Schema
+//  -  DB_APPLICATION_NAME  = ApplicationName
+//  -  DB_USER              = Username
+//  -  DB_PASSWORD          = Password
+//  -  DB_CONNECT_TIMEOUT   = ConnectTimeout
+//  -  DB_LOCK_TIMEOUT      = LockTimeout
+//  -  DB_STATEMENT_TIMEOUT = StatementTimeout
+//  -  DB_SSLMODE           = SSLMode
+//  -  DB_IDLE_CONNECTIONS  = IdleConnections
+//  -  DB_MAX_CONNECTIONS   = MaxConnections
+//  -  DB_MAX_LIFETIME      = MaxLifetime
+//  -  DB_BUFFER_POOL_SIZE  = BufferPoolSize
 func NewConfigFromEnv() (config Config, err error) {
 	if err = (&config).Resolve(env.WithVars(context.Background(), env.Env())); err != nil {
 		return

--- a/db/config.go
+++ b/db/config.go
@@ -38,6 +38,8 @@ func NewConfigFromDSN(dsn string) (*Config, error) {
 			config.SSLMode = strings.TrimPrefix(piece, "sslmode=")
 		} else if strings.HasPrefix(piece, "search_path=") {
 			config.Schema = strings.TrimPrefix(piece, "search_path=")
+		} else if strings.HasPrefix(piece, "application_name=") {
+			config.ApplicationName = strings.TrimPrefix(piece, "application_name=")
 		} else if strings.HasPrefix(piece, "connect_timeout=") {
 			config.ConnectTimeout, err = strconv.Atoi(strings.TrimPrefix(piece, "connect_timeout="))
 			if err != nil {
@@ -67,6 +69,7 @@ func NewConfigFromDSN(dsn string) (*Config, error) {
 //	-	DB_PORT              = Port
 //	- 	DB_NAME              = Database
 //	-	DB_SCHEMA            = Schema
+//	-	DB_APPLICATION_NAME  = ApplicationName
 //	-	DB_USER              = Username
 //	-	DB_PASSWORD          = Password
 //	-	DB_CONNECT_TIMEOUT   = ConnectTimeout
@@ -117,6 +120,13 @@ type Config struct {
 	// opened connection such as "SET search_path = 'schema_one,schema_two';" Again, we recommend against this practice
 	// and encourage you to specify schema names beyond the first in your queries.
 	Schema string `json:"schema,omitempty" yaml:"schema,omitempty" env:"DB_SCHEMA"`
+	// ApplicationName is the name set by an application connection to a database
+	// server, intended to be transmitted in the connection string. It can be
+	// used to uniquely identify an application and will be included in the
+	// `pg_stat_activity` view.
+	//
+	// See: https://www.postgresql.org/docs/12/runtime-config-logging.html#GUC-APPLICATION-NAME
+	ApplicationName string `json:"applicationName,omitempty" yaml:"applicationName,omitempty" env:"DB_APPLICATION_NAME"`
 	// Username is the username for the connection via password auth.
 	Username string `json:"username,omitempty" yaml:"username,omitempty" env:"DB_USER"`
 	// Password is the password for the connection via password auth.
@@ -169,6 +179,7 @@ func (c *Config) Resolve(ctx context.Context) error {
 		configutil.SetString(&c.Port, configutil.Env("DB_PORT"), configutil.String(c.Port), configutil.String(DefaultPort)),
 		configutil.SetString(&c.Database, configutil.Env("DB_NAME"), configutil.String(c.Database), configutil.String(DefaultDatabase)),
 		configutil.SetString(&c.Schema, configutil.Env("DB_SCHEMA"), configutil.String(c.Schema)),
+		configutil.SetString(&c.ApplicationName, configutil.Env(EnvVarDBApplicationName), configutil.String(c.ApplicationName)),
 		configutil.SetString(&c.Username, configutil.Env("DB_USER"), configutil.String(c.Username), configutil.Env("USER")),
 		configutil.SetString(&c.Password, configutil.Env("DB_PASSWORD"), configutil.String(c.Password)),
 		configutil.SetInt(&c.ConnectTimeout, configutil.Env("DB_CONNECT_TIMEOUT"), configutil.Int(c.ConnectTimeout), configutil.Int(DefaultConnectTimeout)),
@@ -310,6 +321,9 @@ func (c Config) CreateDSN() string {
 	}
 	if c.Schema != "" {
 		queryArgs.Add("search_path", c.Schema)
+	}
+	if c.ApplicationName != "" {
+		queryArgs.Add("application_name", c.ApplicationName)
 	}
 
 	dsn.RawQuery = queryArgs.Encode()

--- a/db/config_test.go
+++ b/db/config_test.go
@@ -23,48 +23,52 @@ func TestConfigCreateDSN(t *testing.T) {
 		Password:         "dog",
 		Database:         "blend",
 		Schema:           "mortgages",
+		ApplicationName:  "this-pod-7897744df9-v4bbx",
 		SSLMode:          SSLModeVerifyCA,
 		LockTimeout:      1704 * time.Millisecond,
 		StatementTimeout: 2704 * time.Millisecond,
 		ConnectTimeout:   5,
 	}
 
-	assert.Equal("postgres://bailey:dog@bar:1234/blend?connect_timeout=5&lock_timeout=1704ms&search_path=mortgages&sslmode=verify-ca&statement_timeout=2704ms", cfg.CreateDSN())
+	assert.Equal("postgres://bailey:dog@bar:1234/blend?application_name=this-pod-7897744df9-v4bbx&connect_timeout=5&lock_timeout=1704ms&search_path=mortgages&sslmode=verify-ca&statement_timeout=2704ms", cfg.CreateDSN())
 
 	cfg = &Config{
-		DSN:      "foo",
-		Host:     "bar",
-		Username: "bailey",
-		Password: "dog",
-		Database: "blend",
-		Schema:   "mortgages",
-		SSLMode:  SSLModeVerifyCA,
+		DSN:             "foo",
+		Host:            "bar",
+		Username:        "bailey",
+		Password:        "dog",
+		Database:        "blend",
+		Schema:          "mortgages",
+		ApplicationName: "this-pod-7897744df9-v4bbx",
+		SSLMode:         SSLModeVerifyCA,
 	}
 
 	assert.Equal("foo", cfg.CreateDSN())
 
 	cfg = &Config{
-		Host:     "bar",
-		Port:     "1234",
-		Username: "bailey",
-		Password: "dog",
-		Database: "blend",
-		Schema:   "mortgages",
-		SSLMode:  SSLModeVerifyCA,
+		Host:            "bar",
+		Port:            "1234",
+		Username:        "bailey",
+		Password:        "dog",
+		Database:        "blend",
+		Schema:          "mortgages",
+		ApplicationName: "this-pod-7897744df9-v4bbx",
+		SSLMode:         SSLModeVerifyCA,
 	}
 
-	assert.Equal("postgres://bailey:dog@bar:1234/blend?search_path=mortgages&sslmode=verify-ca", cfg.CreateDSN())
+	assert.Equal("postgres://bailey:dog@bar:1234/blend?application_name=this-pod-7897744df9-v4bbx&search_path=mortgages&sslmode=verify-ca", cfg.CreateDSN())
 
 	cfg = &Config{
-		Host:     "bar",
-		Port:     "1234",
-		Username: "bailey",
-		Password: "dog",
-		Database: "blend",
-		Schema:   "mortgages",
+		Host:            "bar",
+		Port:            "1234",
+		Username:        "bailey",
+		Password:        "dog",
+		Database:        "blend",
+		Schema:          "mortgages",
+		ApplicationName: "this-pod-7897744df9-v4bbx",
 	}
 
-	assert.Equal("postgres://bailey:dog@bar:1234/blend?search_path=mortgages", cfg.CreateDSN())
+	assert.Equal("postgres://bailey:dog@bar:1234/blend?application_name=this-pod-7897744df9-v4bbx&search_path=mortgages", cfg.CreateDSN())
 
 	cfg = &Config{
 		Host:     "bar",
@@ -152,7 +156,7 @@ func TestNewConfigFromDSN(t *testing.T) {
 func TestNewConfigFromDSNWithSchema(t *testing.T) {
 	assert := assert.New(t)
 
-	dsn := "postgres://bailey:dog@bar:1234/blend?connect_timeout=5&sslmode=verify-ca&search_path=mortgages"
+	dsn := "postgres://bailey:dog@bar:1234/blend?connect_timeout=5&sslmode=verify-ca&search_path=mortgages&application_name=this-pod-7897744df9-v4bbx"
 
 	parsed, err := NewConfigFromDSN(dsn)
 	assert.Nil(err)
@@ -195,12 +199,13 @@ func TestConfigReparse(t *testing.T) {
 	assert := assert.New(t)
 
 	cfg := &Config{
-		Host:     "bar",
-		Username: "bailey",
-		Password: "dog",
-		Database: "blend",
-		Schema:   "mortgages",
-		SSLMode:  SSLModeVerifyCA,
+		Host:            "bar",
+		Username:        "bailey",
+		Password:        "dog",
+		Database:        "blend",
+		Schema:          "mortgages",
+		ApplicationName: "this-pod-7897744df9-v4bbx",
+		SSLMode:         SSLModeVerifyCA,
 	}
 
 	resolved, err := cfg.Reparse()

--- a/db/config_test.go
+++ b/db/config_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -144,13 +145,17 @@ func TestNewConfigFromDSN(t *testing.T) {
 	dsn = "postgres://bar:1234/blend?lock_timeout=1000"
 	parsed, err = NewConfigFromDSN(dsn)
 	assert.Nil(parsed)
-	assert.Equal("time: missing unit in duration 1000; field: lock_timeout", fmt.Sprintf("%v", err))
+	expectedPattern := `^time: missing unit in duration (")?1000(")?; field: lock_timeout$`
+	re := regexp.MustCompile(expectedPattern)
+	assert.True(re.MatchString(fmt.Sprintf("%v", err)))
 
 	// Failure to parse statement timeout
 	dsn = "postgres://bar:1234/blend?statement_timeout=2000"
 	parsed, err = NewConfigFromDSN(dsn)
 	assert.Nil(parsed)
-	assert.Equal("time: missing unit in duration 2000; field: statement_timeout", fmt.Sprintf("%v", err))
+	expectedPattern = `^time: missing unit in duration (")?2000(")?; field: statement_timeout$`
+	re = regexp.MustCompile(expectedPattern)
+	assert.True(re.MatchString(fmt.Sprintf("%v", err)))
 }
 
 func TestNewConfigFromDSNWithSchema(t *testing.T) {

--- a/db/constants.go
+++ b/db/constants.go
@@ -10,6 +10,12 @@ const (
 
 	// EnvVarDatabaseURL is an environment variable.
 	EnvVarDatabaseURL = "DATABASE_URL"
+	// EnvVarDBApplicationName is the environment variable used to set the
+	// `application_name` configuration parameter in a `lib/pq` connection
+	// string.
+	//
+	// See: https://www.postgresql.org/docs/12/runtime-config-logging.html#GUC-APPLICATION-NAME
+	EnvVarDBApplicationName = "DB_APPLICATION_NAME"
 
 	// DefaultHost is the default database hostname, typically used
 	// when developing locally.


### PR DESCRIPTION
## PR Summary

 - **Type:** Features
 - **Intended Change Level:** minor

#### Reviewers:

Reviewers keep the following in mind while reviewing this PR, and provide an assessment of them in your approval comment:

- Does the "Intended Change Level" above match the actual behavior of this PR?
- Is this PR following patterns set forth in the package (if modifying a package), or the go-sdk design patterns if implementing a new package from scratch?
- Does this require a backport to LTS versions? If so ping, let the contributors group know.