### PR TITLE
`db` - Ensure `readonly` fields not added into Upsert statement

### DIFF
--- a/db/invocation.go
+++ b/db/invocation.go
@@ -605,8 +605,8 @@ func (i *Invocation) generateUpsert(object DatabaseMapped) (statementLabel, quer
 	updates := cols.UpdateColumns()
 	updateCols := updates.Columns()
 
-	// We add in all the autos columns to start
-	insertsWithAutos = cols.InsertColumns().ConcatWith(cols.Autos())
+	// We add in all the non-readonly autos columns to start
+	insertsWithAutos = cols.InsertColumns().ConcatWith(cols.NotReadOnly().Autos())
 	pks := insertsWithAutos.PrimaryKeys()
 
 	// But we exclude auto primary keys that are not set. Auto primary keys that ARE set must be included in the insert

--- a/db/invocation_test.go
+++ b/db/invocation_test.go
@@ -832,13 +832,13 @@ func Test_Invocation_Upsert_withReadOnlyAuto(t *testing.T) {
 		Category: "Category",
 	}
 
-	its.Zero(value.UUID)
-	its.Zero(value.Timestamp)
+	its.True(value.UUID.IsZero())
+	its.True(value.Timestamp.IsZero())
 
 	err = defaultDB().Invoke(OptTx(tx)).Upsert(&value)
 	its.Nil(err)
-	its.NotZero(value.UUID)
-	its.NotZero(value.Timestamp)
+	its.False(value.UUID.IsZero())
+	its.False(value.Timestamp.IsZero())
 
 	insertID := value.UUID
 	insertTimestamp := value.Timestamp
@@ -861,8 +861,8 @@ func Test_Invocation_Upsert_withReadOnlyAuto(t *testing.T) {
 
 	err = defaultDB().Invoke(OptTx(tx)).Upsert(&valueUpdate)
 	its.Nil(err)
-	its.NotZero(valueUpdate.UUID)
-	its.NotZero(valueUpdate.Timestamp)
+	its.False(valueUpdate.UUID.IsZero())
+	its.False(valueUpdate.Timestamp.IsZero())
 	its.Equal(insertID, valueUpdate.UUID)
 	// make sure the timestamp did not change since it's a readonly field
 	// but got loaded in because it's also an auto field

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -149,6 +149,26 @@ func createUpsertNoAutosObjectTable(tx *sql.Tx) error {
 	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec(createSQL))
 }
 
+type upsertReadOnlyAuto struct {
+	UUID      uuid.UUID `db:"uuid,pk"`
+	Timestamp time.Time `db:"timestamp_utc,auto,readonly"`
+	Category  string    `db:"category"`
+}
+
+func (ur upsertReadOnlyAuto) TableName() string {
+	return "upsery_readonly_auto"
+}
+
+func createUpsertReadOnlyAutoObjectTable(tx *sql.Tx) error {
+	createSQL := `CREATE TABLE IF NOT EXISTS upsert_readonly_auto (uuid varchar(255) primary key, timestamp_utc timestamp default (clock_timestamp() at time zone 'utc'), category varchar(255));`
+	return IgnoreExecResult(defaultDB().Invoke(OptTx(tx)).Exec(createSQL))
+}
+
+func dropUpsertReadOnlyAutoTable(tx *sql.Tx) error {
+	_, err := defaultDB().Invoke(OptTx(tx)).Exec("DROP TABLE upsert_readonly_auto")
+	return err
+}
+
 //------------------------------------------------------------------------------------------------
 // Benchmarking
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- currently this will happen if a field is marked as `readonly` & `auto`
- a field such as `created_at` could be auto and read-only